### PR TITLE
config: Update data model extensions

### DIFF
--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -355,10 +355,6 @@ ILS_RECORDS_METADATA_EXTENSIONS = {
             "elasticsearch": "keyword",
             "marshmallow": SanitizedUnicode(),
         },
-        "unit:legacy_name": {
-            "elasticsearch": "keyword",
-            "marshmallow": SanitizedUnicode(),
-        },
         "unit:project": {
             "elasticsearch": "keyword",
             "marshmallow": SanitizedUnicode(),

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -55,11 +55,6 @@ export const config = {
           type: 'string',
           default: '',
         },
-        'unit:legacy_name': {
-          label: 'Legacy Name',
-          type: 'string',
-          default: '',
-        },
         'unit:project': {
           label: 'Project',
           type: 'string',


### PR DESCRIPTION
* Remove `legacy_name` of accelerators
  from data model extensions
* closes #120