### PR TITLE
patron: CERN specific metadata

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "react-scripts": "^3.4.1"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "HTTPS=true craco start",
     "build": "craco build",
     "test": "craco test",
     "eject": "craco eject"

--- a/ui/src/overridableMapping.js
+++ b/ui/src/overridableMapping.js
@@ -1,4 +1,8 @@
 import { DeliveryIcon } from './overridden/backoffice/DeliveryIcon/DeliveryIcon';
+import {
+  PatronMetadata,
+  PatronMetadataActionMenuItem,
+} from './overridden/backoffice/PatronMetadata/PatronMetadata';
 import { Footer } from './overridden/components/Footer/Footer';
 import {
   Logo,
@@ -14,6 +18,8 @@ import {
 import { Slogan } from './overridden/frontsite/Home/Slogan';
 
 export const overriddenCmps = {
+  'Backoffice.PatronDetails.Metadata': PatronMetadata,
+  'Backoffice.PatronDetails.Metadata.ActionMenuItem': PatronMetadataActionMenuItem,
   'Home.Headline': HomeHeadline,
   'Home.Headline.slogan': Slogan,
   'Home.content': HomeContent,

--- a/ui/src/overridden/backoffice/PatronMetadata/PatronMetadata.js
+++ b/ui/src/overridden/backoffice/PatronMetadata/PatronMetadata.js
@@ -1,0 +1,45 @@
+import {
+  ScrollingMenuItem,
+  MetadataTable,
+} from '@inveniosoftware/react-invenio-app-ils';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Grid, Header, Segment } from 'semantic-ui-react';
+
+export const PatronMetadata = ({ patron, ...props }) => {
+  const leftTable = [
+    { name: 'Name', value: patron.metadata.name },
+    { name: 'Email', value: patron.metadata.email },
+  ];
+  const rightTable = [
+    { name: 'Person ID', value: patron.metadata.person_id },
+    { name: 'Department', value: patron.metadata.department },
+  ];
+  return (
+    <>
+      <Header attached="top" as="h3">
+        Patron metadata
+      </Header>
+      <Segment attached className="bo-metadata-segment" id="patron-metadata">
+        <Grid columns={2}>
+          <Grid.Row>
+            <Grid.Column>
+              <MetadataTable labelWidth={5} rows={leftTable} />
+            </Grid.Column>
+            <Grid.Column>
+              <MetadataTable labelWidth={5} rows={rightTable} />
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Segment>
+    </>
+  );
+};
+
+export const PatronMetadataActionMenuItem = ({ ...props }) => (
+  <ScrollingMenuItem label="Patron metadata" elementId="patron-metadata" />
+);
+
+PatronMetadata.propTypes = {
+  patron: PropTypes.object.isRequired,
+};


### PR DESCRIPTION
- NEW enable https
- NEW metadata table for CERN specific patron details
- NEW patron details action menu for metadata
- closes #145

<img width="1681" alt="Screenshot 2020-09-23 at 1 49 11 PM" src="https://user-images.githubusercontent.com/230805/94008697-b7995f80-fda3-11ea-9cd4-d31cc7b50192.png">