### PR TITLE
rework footer and contacts

### DIFF
--- a/cds_ils/cli.py
+++ b/cds_ils/cli.py
@@ -66,21 +66,28 @@ def pages():
             title="About",
             description="About",
             content=page_data("about.html"),
-            template_name="invenio_pages/default.html",
+            template_name="invenio_pages/dynamic.html",
         ),
         Page(
             url="/terms",
             title="Terms",
             description="Terms",
             content=page_data("terms.html"),
-            template_name="invenio_pages/default.html",
+            template_name="invenio_pages/dynamic.html",
         ),
         Page(
             url="/faq",
             title="F.A.Q.",
             description="F.A.Q.",
             content=page_data("faq.html"),
-            template_name="invenio_pages/default.html",
+            template_name="invenio_pages/dynamic.html",
+        ),
+        Page(
+            url="/contact",
+            title="Contact",
+            description="Contact",
+            content=page_data("contact.html"),
+            template_name="invenio_pages/dynamic.html",
         ),
     ]
     with db.session.begin_nested():

--- a/cds_ils/static_pages/about.html
+++ b/cds_ils/static_pages/about.html
@@ -1,11 +1,5 @@
-<!DOCTYPE html>
-<html>
-<body>
-
-<p>The CERN Library catalogue includes all the collections available at the CERN Library. It includes more than 115,000 books, 23,000 conference proceedings, almost 14,000 standards and some 2400 journal titles. Most of those documents are available in electronic format. </p>
+<p>The CERN Library Catalogue includes all the collections available at the CERN Library. It includes more than 115,000 books, 23,000 conference proceedings, almost 14,000 standards and some 2400 journal titles. Most of those documents are available in electronic format.</p>
 <p>In order to access those documents, you can search within the catalogue, and either access the document online or borrow the physical copy from the Library. If you do not want to come to the Library, you can request the document online, and we'll send it to you by internal mail.</p>
-<p>If you do not find what you are looking for or would like to purchase a document, do not hesitate to request the document you need via this <a href="/request">form</a>, or contact us by <a href="mailto:library.desk@cern.ch">email</a>. </p>
-<p>The CERN Library catalogue includes only documents acquired by the Library, if you are looking for CERN scientific publications such as preprints, published articles or theses written by CERN Authors or collaborations, please consult the CERN institutional repository <a href="http://cds.cern.ch">CERN Document Server</a>.</p>
-<p>The CERN Library collections are managed by RCS-SIS, the technical infrastructure of the catalogue is maintained by IT-CDA. </p>
-</body>
-</html>
+<p>If you do not find what you are looking for or would like to purchase a document, do not hesitate to request the document you need via this <a href="/request">form</a> or <a href="/contact">contact us</a>.</p>
+<p>The CERN Library Catalogue includes only documents acquired by the Library. If you are looking for CERN scientific publications such as preprints, published articles or theses written by CERN Authors or collaborations, please consult the CERN institutional repository <a href="https://cds.cern.ch" target="_blank" rel="noopener noreferrer">CERN Document Server</a>.</p>
+<p>The CERN Library Catalague content is managed by the section RCS-SIS and the technical infrastructure of the catalogue by section IT-CDA-DR.</p>

--- a/cds_ils/static_pages/contact.html
+++ b/cds_ils/static_pages/contact.html
@@ -1,0 +1,19 @@
+<h3>Catalogue and loans questions</h3>
+
+<p>Please contact the CERN Library by email at <a href="mailto:library.desk@cern.ch">library.desk@cern.ch</a> for any question related to:</p>
+<ul>
+  <li>catalogue: how to find documents, different versions and editions or to get more details</li>
+  <li>e-books: how to get access or download</li>
+  <li>loaning: how to request, extend, return or cancel a loan</li>
+  <li>purchase or InterLibrary loans: how to buy a book or obtain it from another library</li>
+  <li>issues with the EDH termination sheets</li>
+</ul>
+
+<h3>Technical Support</h3>
+
+<p>For any question related to the technical issues with the website (error, bug, feature not working, etc...), please contact <a href="https://cern.service-now.com/service-portal?id=functional_element&name=CDS" target="_blank" rel="noopener noreferrer">CDS support</a>. In your message, please provide:</p>
+<ul>
+  <li>the URL where the issue has been found, with the error message and code if available</li>
+  <li>a description of the issue with any relevant information on how to reproduce it</li>
+  <li>if possible and useful, a screenshot</li>
+</ul>

--- a/cds_ils/static_pages/faq.html
+++ b/cds_ils/static_pages/faq.html
@@ -1,17 +1,12 @@
-<!DOCTYPE html>
-<html>
-<body>
-
-
 <h3>What are the Library desk opening hours?</h3>
-<p>The Library is open 24/7 but the library desk (loans, returns, enquiries) is open: Monday - Friday, 8:30 a.m. - 6 p.m.
+<p>While the Library is open 24/7, you can find the library's desk (loans, returns, enquiries) opening hours <a href="/opening-hours">here</a>.
 <p>You can return books outside these opening hours by depositing them in the red box in the entrance.
 
 <h3>How do I borrow books?</h3>
-<p>You can borrow books at the Library desk (bldg. 52-1-052, Monday - Friday, 8:30 a.m. - 6 p.m.) with your CERN card. Or, you can request books online on the Library catalogue: search for the book and click on "request". The books will be delivered by internal mail to your office or kept for you at the Library desk.</p>
+<p>You can borrow books at the Library desk (bldg. 52-1-052) with your CERN card. Or, you can request books online on the Library Catalogue: search for the book and click on "request". The books will be delivered by internal mail to your office or kept for you at the Library desk.</p>
 
 <h3>How long is a loan duration?</h3>
-<p>The normal loan period is 1 week or 4 weeks, depending on the document type, and is renewable if nobody else has requested the document. To check your loans and renew them, see your online profile page.</p>
+<p>The normal loan period is 1 week or 4 weeks, depending on the document type, and is renewable if nobody else has requested the document. To check your loans and renew them, see <a href="/profile">Your Loans</a> page.</p>
 
 <h3>How many books can I borrow?</h3>
 <p>There is no maximum. Borrow as many as you want!</p>
@@ -20,10 +15,10 @@
 <p>Yes, simply write "Library" as recipient on the envelope.</p>
 
 <h3>I returned my books but they still appear on my termination sheet. What should I do?</h3>
-<p>EDH termination sheets are not updated automatically. Please contact us: <a href="mailto:library.desk@cern.ch">library.desk@cern.ch</a> to get it signed.</p>
+<p>EDH termination sheets are not updated automatically. Please <a href="/contact">contact us</a> to get it signed.</p>
 
 <h3>How do I renew my loans?</h3>
-<p>Go on your <a href="/profile">profile page</a>.</p>
+<p>Go to <a href="/profile">Your Loans</a> page.</p>
 
 <h3>How do I renew my loans for books borrowed from other libraries?</h3>
 <p>Interlibrary loans can usually be renewed. Reply to the recall email you receive at the end of the loan period and we will get back to you as soon as possible.</p>
@@ -48,8 +43,5 @@
 <p>With the remote access to e-resources.</p>
 
 <h3>I cannot find a CERN document I'm looking for, why is it not in the Library catalogue?</h3>
-<p>The CERN Library catalogue includes only documents acquired by the Library (books, proceedings, journals and standards), if you are looking for CERN scientific publications such as preprints, published articles or theses written by CERN Authors or collaborations, please consult the CERN institutional repository CERN Document Server within the collection "CERN Articles & Preprints".</p>
+<p>The CERN Library Catalogue includes only documents acquired by the Library (books, proceedings, journals and standards), if you are looking for CERN scientific publications such as preprints, published articles or theses written by CERN Authors or collaborations, please consult the CERN institutional repository <a href="https://cds.cern.ch" target="_blank" rel="noopener noreferrer">CERN Document Server</a> within the collection "CERN Articles & Preprints".</p>
 <p>Non-CERN articles and preprints are generally not covered by CDS, which is focussing on CERN scientific output. Comprehensive searches for literature in High Energy Physics should be performed in INSPIRE.</p>
-
-</body>
-</html>

--- a/cds_ils/static_pages/terms.html
+++ b/cds_ils/static_pages/terms.html
@@ -1,7 +1,1 @@
-<!DOCTYPE html>
-<html>
-<body>
-
-<h1> Terms </h1>
-</body>
-</html>
+<p>Coming soon</p>

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0a15",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.16",
+    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.17",
     "axios": "^0.19.2",
     "formik": "^2.1.4",
     "less": "^3.11.1",

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -1,13 +1,12 @@
 export const config = {
   APP: {
     LOGO_SRC: null,
-    staticPages: [
+    STATIC_PAGES: [
       { name: 'about', route: '/about', apiURL: '1' },
       { name: 'terms', route: '/terms', apiURL: '2' },
       { name: 'faq', route: '/faq', apiURL: '3' },
+      { name: 'contact', route: '/contact', apiURL: '4' },
     ],
-    supportEmail: 'cds.support@cern.ch',
-    libraryEmail: 'library.desk@cern.ch',
     ENABLE_LOCAL_ACCOUNT_LOGIN: false,
     OAUTH_PROVIDERS: {
       github: {

--- a/ui/src/overridden/components/Footer/Footer.js
+++ b/ui/src/overridden/components/Footer/Footer.js
@@ -1,7 +1,6 @@
 import {
   FrontSiteRoutes,
   getStaticPageByName,
-  invenioConfig,
 } from '@inveniosoftware/react-invenio-app-ils';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -15,33 +14,8 @@ export const Footer = ({ ...props }) => {
         <Container>
           <Grid columns={4} stackable>
             <Grid.Column>
-              <Header as="h4" content="CERN Library" />
-              <p>
-                <Link to={FrontSiteRoutes.openingHours}>
-                  Opening hours and holidays
-                </Link>
-              </p>
-            </Grid.Column>
-            <Grid.Column>
-              <Header as="h4" content="Help" />
-              <List>
-                <List.Item>
-                  <Link to={FrontSiteRoutes.documentRequestForm}>
-                    Request new literature
-                  </Link>
-                </List.Item>
-                <List.Item>
-                  <a
-                    href="https://library.web.cern.ch"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Scientific Information Service
-                  </a>
-                </List.Item>
-                <List.Item>
-                  <Link to={getStaticPageByName('faq').route}>F.A.Q.</Link>
-                </List.Item>
+              <Header as="h4" content="About" />
+              <List relaxed>
                 <List.Item>
                   <Link to={getStaticPageByName('about').route}>About</Link>
                 </List.Item>
@@ -53,20 +27,36 @@ export const Footer = ({ ...props }) => {
               </List>
             </Grid.Column>
             <Grid.Column>
-              <Header as="h4" content="Contact us" />
-              <List>
-                <List.Item>+41 22 767 24 35</List.Item>
+              <Header as="h4" content="Need help?" />
+              <List relaxed>
                 <List.Item>
-                  <a href={`mailto:${invenioConfig.APP.libraryEmail}`}>
-                    {invenioConfig.APP.libraryEmail}
-                  </a>
+                  <Link to={getStaticPageByName('contact').route}>
+                    Contact us
+                  </Link>
+                </List.Item>
+                <List.Item>
+                  <Link to={getStaticPageByName('faq').route}>F.A.Q.</Link>
+                </List.Item>
+                <List.Item>
+                  <Link to={FrontSiteRoutes.documentRequestForm}>
+                    Request new literature
+                  </Link>
                 </List.Item>
               </List>
-              <Header as="h4" content="Technical Support" />
-              <List>
+            </Grid.Column>
+            <Grid.Column>
+              <Header as="h4" content="CERN Library" />
+              <List relaxed>
                 <List.Item>
-                  <a href={`mailto:${invenioConfig.APP.supportEmail}`}>
-                    {invenioConfig.APP.supportEmail}
+                  <Link to={FrontSiteRoutes.openingHours}>Opening hours</Link>
+                </List.Item>
+                <List.Item>
+                  <a
+                    href="https://scientific-info.cern"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Scientific Information Service
                   </a>
                 </List.Item>
               </List>

--- a/ui/src/overridden/components/Menu/RightMenuItem.js
+++ b/ui/src/overridden/components/Menu/RightMenuItem.js
@@ -1,7 +1,6 @@
 import {
   FrontSiteRoutes,
   getStaticPageByName,
-  invenioConfig,
 } from '@inveniosoftware/react-invenio-app-ils';
 import React from 'react';
 import { Link } from 'react-router-dom';
@@ -18,7 +17,7 @@ const DropdownItems = () => {
         F.A.Q.
       </Dropdown.Item>
       <Dropdown.Divider />
-      <Dropdown.Item as="a" href={`mailto:${invenioConfig.APP.libraryEmail}`}>
+      <Dropdown.Item as={Link} to={getStaticPageByName('contact').route}>
         Ask a librarian
       </Dropdown.Item>
       <Dropdown.Divider />


### PR DESCRIPTION
Remove emails around and use only the `contact` page with clear instructions on who/how to contact:

<img width="1306" alt="CERN_Library_Catalogue" src="https://user-images.githubusercontent.com/2089455/97106017-68568f80-16bf-11eb-8c02-2bf41f0d4354.png">

Needs release of `react-invenio-app-ils` with [this PR](https://github.com/inveniosoftware/react-invenio-app-ils/pull/251) merged.