### PR TITLE
patrons: index patrons only if they have remote account

### DIFF
--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -47,6 +47,7 @@ from marshmallow.fields import Bool, List
 from .circulation.utils import circulation_cds_extension_max_count
 from .literature.covers import build_cover_urls
 from .patrons.api import AnonymousPatron, Patron
+from .patrons.indexer import PatronIndexer
 from .patrons.permissions import views_permissions_factory
 
 
@@ -360,6 +361,7 @@ JSONSCHEMAS_SCHEMAS = [
 # RECORDS REST
 ###############################################################################
 RECORDS_REST_ENDPOINTS[PATRON_PID_TYPE]["record_class"] = Patron
+RECORDS_REST_ENDPOINTS[PATRON_PID_TYPE]["indexer_class"] = PatronIndexer
 RECORDS_REST_ENDPOINTS[LOCATION_PID_TYPE][
     "create_permission_factory_imp"
 ] = deny_all
@@ -639,3 +641,5 @@ CDS_ILS_IMPORTER_FILE_EXTENSIONS_ALLOWED = [".xml"]
 CDS_ILS_IMPORTER_PROVIDERS_ALLOWED_TO_DELETE_RECORDS = ["ebl", "safari"]
 
 RECORD_LEGACY_PID_TYPE = "lrecid"
+
+CDS_ILS_INDEX_LOCAL_ACCOUNTS = True

--- a/cds_ils/ldap/api.py
+++ b/cds_ils/ldap/api.py
@@ -19,7 +19,7 @@ from flask import current_app
 from invenio_accounts.models import User
 from invenio_app_ils.errors import AnonymizationActiveLoansError
 from invenio_app_ils.patrons.anonymization import anonymize_patron_data
-from invenio_app_ils.patrons.indexer import PatronBaseIndexer, reindex_patrons
+from invenio_app_ils.patrons.indexer import PatronBaseIndexer
 from invenio_app_ils.proxies import current_app_ils
 from invenio_db import db
 from invenio_oauthclient.models import RemoteAccount, UserIdentity
@@ -244,7 +244,7 @@ def import_users():
     print("Users imported: {}".format(imported))
     print("Now re-indexing all patrons...")
 
-    reindex_patrons()
+    current_app_ils.patron_indexer.reindex_patrons()
 
     print("--- Finished in %s seconds ---" % (time.time() - start_time))
 
@@ -547,6 +547,6 @@ def delete_users(dry_run=True):
                 invenio_users_deleted_count += 1
 
     if not dry_run:
-        reindex_patrons()
+        current_app_ils.patron_indexer.reindex_patrons()
 
     return len(ldap_users), invenio_users_deleted_count

--- a/cds_ils/patrons/indexer.py
+++ b/cds_ils/patrons/indexer.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2021 CERN.
+#
+# CDS-ILS is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+"""Patron Indexer for CDS-ILS."""
+
+from flask import current_app
+from invenio_accounts.models import User
+from invenio_app_ils.patrons.indexer import PatronBaseIndexer
+from invenio_app_ils.patrons.indexer import PatronIndexer as ILSPatronIndexer
+from invenio_app_ils.proxies import current_app_ils
+from invenio_db import db
+from invenio_oauthclient.models import RemoteAccount
+
+
+class PatronIndexer(ILSPatronIndexer):
+    """Indexer class for `Patron`."""
+
+    def reindex_patrons(self):
+        """Re-index all patrons."""
+        # do not use PatronIndexer class otherwise it will trigger potentially
+        # thousands of tasks to index referenced records
+        indexer = PatronBaseIndexer()
+        Patron = current_app_ils.patron_cls
+        # cannot use bulk operation because Patron is not a real record
+        index_local_accounts = current_app.config[
+            "CDS_ILS_INDEX_LOCAL_ACCOUNTS"
+        ]
+        if index_local_accounts:
+            all_user_ids = db.session.query(User.id).all()
+        else:
+            all_user_ids = db.session.query(RemoteAccount.user_id).all()
+        for (user_id,) in all_user_ids:
+            patron = Patron(user_id)
+            indexer.index(patron)
+
+        return len(all_user_ids)

--- a/tests/api/test_indexing.py
+++ b/tests/api/test_indexing.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2021 CERN.
+#
+# CDS-ILS is free software; you can redistribute it and/or modify it under
+# the terms of the MIT License; see LICENSE file for more details.
+
+from flask import current_app
+from invenio_app_ils.proxies import current_app_ils
+
+
+def test_local_accounts_indexing(app, patron1, patron2, testdata):
+    """Test if local accounts get indexed or not."""
+
+    current_app_ils.patron_indexer.reindex_patrons()
+
+    index_local_accounts = current_app.config["CDS_ILS_INDEX_LOCAL_ACCOUNTS"]
+    if not index_local_accounts:
+        assert current_app_ils.patron_indexer.reindex_patrons() == 1
+    else:
+        assert current_app_ils.patron_indexer.reindex_patrons() == 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,27 @@ def patron1(app, db):
 
 
 @pytest.fixture()
+def patron2(app, db):
+    """Create a patron user without remote account."""
+    user = User(**dict(email="patron2@cern.ch", active=True))
+    db.session.add(user)
+    db.session.commit()
+
+    user_id = user.id
+
+    profile = UserProfile(
+        **dict(
+            user_id=user_id,
+            _displayname="id_" + str(user_id),
+            full_name="System User",
+        )
+    )
+    db.session.add(profile)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
 def testdata(app, db, es_clear, patron1):
     """Create, index and return test data."""
     data = load_json_from_datadir("locations.json")

--- a/tests/ldap/test_ldap.py
+++ b/tests/ldap/test_ldap.py
@@ -11,8 +11,8 @@ from copy import deepcopy
 
 import pytest
 from invenio_accounts.models import User
-from invenio_app_ils.patrons.indexer import reindex_patrons
 from invenio_app_ils.patrons.search import PatronsSearch
+from invenio_app_ils.proxies import current_app_ils
 from invenio_oauthclient.models import RemoteAccount, UserIdentity
 from invenio_search import current_search
 from invenio_userprofiles.models import UserProfile
@@ -180,7 +180,7 @@ def test_update_users(app, db, testdata, mocker):
         }
         importer.import_user(COULD_BE_DELETED)
         db.session.commit()
-        reindex_patrons()
+        current_app_ils.patron_indexer.reindex_patrons()
 
     _prepare()
 


### PR DESCRIPTION
- override `reindex_patrons` function with function that also checks if user has a remote account
- add configuration to whether local accounts should be indexed or not


Depends on inveniosoftware/invenio-app-ils#1012
Closes #246