### PR TITLE
migration: fix import document requests

### DIFF
--- a/cds_ils/importer/providers/cds/rules/base.py
+++ b/cds_ils/importer/providers/cds/rules/base.py
@@ -16,7 +16,8 @@ from dateutil import parser
 from dateutil.parser import ParserError
 from dojson.errors import IgnoreKey
 from dojson.utils import filter_values, flatten, for_each_value, force_list
-from invenio_app_ils.relations.api import EDITION_RELATION, OTHER_RELATION
+from invenio_app_ils.relations.api import EDITION_RELATION, \
+    LANGUAGE_RELATION, OTHER_RELATION
 
 from cds_ils.importer.errors import ManualImportRequired, \
     MissingRequiredField, UnexpectedValue
@@ -333,12 +334,13 @@ def related_records(self, key, value):
     relation_type = OTHER_RELATION.name
     try:
         if key == "775__" and "b" in value:
-            relation_edition = clean_val("b", value, str)
-            if relation_edition:
+            relation_type_tag = clean_val("x", value, str)
+            if relation_type_tag.lower() == 'edition':
                 relation_type = EDITION_RELATION.name
+            elif relation_type_tag.lower() == 'language':
+                relation_type = LANGUAGE_RELATION.name
         if key == "787__" and "i" in value:
             clean_val("i", value, str, manual=True)
-
         _related.append(
             {
                 "related_recid": clean_val("w", value, str, req=True),

--- a/cds_ils/migrator/document_requests/api.py
+++ b/cds_ils/migrator/document_requests/api.py
@@ -32,8 +32,8 @@ def migrate_document_request(record):
 
     if record["status"] == "proposal-put aside":
         state = "REJECTED"
-        reject_reason = record["library_notes"]
-        new_docreq.update(state=state, reject_reason=reject_reason)
+        new_docreq.update(state=state,
+                          reject_reason="OTHER")
 
     note = get_acq_ill_notes(record)
     if note:

--- a/cds_ils/migrator/items/api.py
+++ b/cds_ils/migrator/items/api.py
@@ -51,7 +51,7 @@ def set_document_pid(record):
         record["document_pid"] = get_record_by_legacy_recid(
             document_cls, record["id_bibrec"]
         ).pid.pid_value
-    except DocumentMigrationError:
+    except PIDDoesNotExistError as e:
         error_logger.error(
             "ITEM: {0} ERROR: Document {1} not found".format(
                 record["barcode"], record["id_bibrec"]
@@ -64,7 +64,7 @@ def set_document_pid(record):
             record["document_pid"] = get_document_by_barcode(
                 record["barcode"], record["id_bibrec"]
             ).pid.pid_value
-        except PIDDoesNotExistError as e:
+        except DocumentMigrationError as e:
             error_logger.error(
                 "ITEM: {0} ERROR: Document {1} not found".format(
                     record["barcode"], record["id_bibrec"]
@@ -90,7 +90,9 @@ def import_items_from_json(dump_file, rectype="item"):
 
             try:
                 set_document_pid(record)
-            except PIDDoesNotExistError:
+            except DocumentMigrationError:
+                # there are items on the list which are not to be migrated
+                # if no document found
                 continue
 
             # clean the item JSON

--- a/cds_ils/migrator/items/utils.py
+++ b/cds_ils/migrator/items/utils.py
@@ -63,8 +63,10 @@ def clean_description_field(record):
 
 def clean_item_record(record):
     """Clean the item record object."""
-    clean_circulation_restriction(record)
+    # Attention! order of cleaning matters,
+    # circulation restriction updates item status
     clean_item_status(record)
+    clean_circulation_restriction(record)
     clean_description_field(record)
     record["shelf"] = record["location"]
     record["medium"] = "PAPER"  # requested as default value

--- a/cds_ils/migrator/patrons/api.py
+++ b/cds_ils/migrator/patrons/api.py
@@ -54,8 +54,11 @@ def import_users_from_json(dump_file):
                     user_id=user.id, client_id=client_id
                 )
                 extra_data = account.extra_data
+                if "legacy_id" in extra_data:
+                    del extra_data["legacy_id"]
                 # add legacy_id information
-                account.extra_data.update(legacy_id=record["id"], **extra_data)
+                account.extra_data.update(legacy_id=str(record["id"]),
+                                          **extra_data)
                 db.session.add(account)
                 patron = Patron(user.id)
                 PatronIndexer().index(patron)

--- a/scripts/life_data_setup
+++ b/scripts/life_data_setup
@@ -16,6 +16,7 @@ invenio fixtures pages
 invenio fixtures location
 invenio fixtures vocabularies
 invenio fixtures demo-patrons
+cds-ils migration create-unknown-reference-records
 invenio files location --default ils /tmp/ils-files # (local)
 cds-ils user-testing import-demo-data --are-docs --path $DOCUMENTS_PATH --verbose
 cds-ils user-testing import-demo-data --are-items --path $ITEMS_PATH  --verbose

--- a/scripts/setup
+++ b/scripts/setup
@@ -9,3 +9,4 @@
 invenio setup --skip-pages --skip-vocabularies --verbose
 invenio fixtures pages
 invenio fixtures vocabularies
+cds-ils migration create-unknown-reference-records

--- a/tests/migrator/test_books.py
+++ b/tests/migrator/test_books.py
@@ -1062,6 +1062,7 @@ def test_related_record(app):
                 <subfield code="b">Test text</subfield>
                 <subfield code="c">Random text</subfield>
                 <subfield code="w">748392</subfield>
+                <subfield code="x">language</subfield>
             </datafield>
             """,
             {
@@ -1071,7 +1072,7 @@ def test_related_record(app):
                     "related": [
                         {
                             "related_recid": "748392",
-                            "relation_type": "edition",
+                            "relation_type": "language",
                         }
                     ],
                 },


### PR DESCRIPTION
fixed problem:
<img width="2774" alt="Screenshot 2021-01-15 at 15 04 27" src="https://user-images.githubusercontent.com/38131488/104931374-9984ea00-59a6-11eb-88c9-53b1994c2a6a.png">

the cancel reasons were quite random, while the ones we have are controlled
I moved the library notes to internal note field(https://github.com/inveniosoftware/invenio-app-ils/pull/1013), but the question is do we actually need it ? 
