### PR TITLE
global: fix login on CERN QA Auth

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,6 +25,7 @@ include babel.ini
 include LICENSE
 include pytest.ini
 include scripts/bootstrap
+include scripts/celery
 include scripts/console
 include scripts/server
 include scripts/setup

--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -265,6 +265,9 @@ _OAUTH_REMOTE_APP_COMMON = dict(
         "protocol/openid-connect/auth",
     ),
 )
+OAUTHCLIENT_CERN_OPENID_USERINFO_URL = \
+    "https://keycloak-qa.cern.ch/auth/realms/cern/" \
+    "protocol/openid-connect/userinfo"
 OAUTHCLIENT_CERN_OPENID_ALLOWED_ROLES = ["cern-user", "librarian", "admin"]
 CERN_APP_OPENID_CREDENTIALS = dict(
     consumer_key=os.environ.get(

--- a/requirements.pinned.txt
+++ b/requirements.pinned.txt
@@ -90,7 +90,7 @@ invenio-logging==1.3.0
 invenio-mail==1.0.2
 invenio-oaiserver==1.2.0
 invenio-oauth2server==1.3.2
-invenio-oauthclient==1.4.2
+invenio-oauthclient==1.4.4
 invenio-opendefinition==1.0.0a9
 invenio-pages==1.0.0a5
 invenio-pidrelations==1.0.0a7

--- a/scripts/celery
+++ b/scripts/celery
@@ -6,13 +6,5 @@
 # CDS-ILS is free software; you can redistribute it and/or modify it under
 # the terms of the MIT License; see LICENSE file for more details.
 
-set -e
-
-script_path=$(dirname "$0")
-
-export FLASK_ENV=development
-export SERVER_NAME=127.0.0.1:5000
-
-invenio run \
-  --cert "$script_path"/../docker/nginx/test.crt \
-  --key "$script_path"/../docker/nginx/test.key
+# You can pass the --beat argument if you want the beat to run
+celery -A invenio_app.celery worker -l INFO


### PR DESCRIPTION
- bump invenio-oauthclient to fix authentication
- split server and celery scripts