### PR TITLE
migration: journal fixes

### DIFF
--- a/cds_ils/importer/providers/cds/cds.py
+++ b/cds_ils/importer/providers/cds/cds.py
@@ -12,10 +12,10 @@ from cds_ils.importer.base_model import Base
 from cds_ils.importer.base_model import model as model_base
 
 
-def get_helper_dict():
+def get_helper_dict(record_type):
     """Return migration extra data."""
     _helper_dict = dict(
-        record_type="document",
+        record_type=record_type,
         volumes=[],
         volumes_identifiers=[],
         volumes_urls=[],

--- a/cds_ils/importer/providers/cds/models/document.py
+++ b/cds_ils/importer/providers/cds/models/document.py
@@ -36,7 +36,9 @@ class CDSDocument(CdsIlsOverdo):
 
     __ignore_keys__ = CDS_IGNORE_FIELDS | __model_ignore_keys__
 
-    _default_fields = {"_migration": {**get_helper_dict()}}
+    _default_fields = {
+        "_migration": {**get_helper_dict(record_type="document")}
+    }
 
     def do(
         self,

--- a/cds_ils/importer/providers/cds/models/journal.py
+++ b/cds_ils/importer/providers/cds/models/journal.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 
 from cds_ils.importer.overdo import CdsIlsOverdo
 
+from ..cds import get_helper_dict
 from ..cds import model as cds_base
 from ..ignore_fields import CDS_IGNORE_FIELDS
 from .document import model as books_base
@@ -72,19 +73,22 @@ class CDSJournal(CdsIlsOverdo):
         "960__c",
         "980__a",
         "980__b",
+        "555__a",
+        "85642x",
+        "866__z",
+        "938__i",
+        "866__c",
+        "85641a",
+        "246_3C",
+        "222__b",
+        "340__z",
+        "697C_a",
     }
 
     __ignore_keys__ = CDS_IGNORE_FIELDS | __model_ignore_keys__
     _default_fields = {
         "_migration": {
-            "has_related": False,
-            "related": [],
-            "record_type": "journal",
-            "volumes": [],
-            "electronic_items": [],
-            "tags": [],
-            "item_medium": [],
-            "has_medium": False,
+            **get_helper_dict(record_type="journal")
         }
     }
 

--- a/cds_ils/importer/providers/cds/models/multipart.py
+++ b/cds_ils/importer/providers/cds/models/multipart.py
@@ -30,7 +30,7 @@ class CDSMultipart(CdsIlsOverdo):
     __ignore_keys__ = CDS_IGNORE_FIELDS
 
     _default_fields = {
-        "_migration": {**get_helper_dict()},
+        "_migration": {**get_helper_dict(record_type="document")},
         "mode_of_issuance": "MULTIPART_MONOGRAPH",
     }
 

--- a/cds_ils/importer/providers/cds/models/standard.py
+++ b/cds_ils/importer/providers/cds/models/standard.py
@@ -26,7 +26,9 @@ class CDSStandard(CdsIlsOverdo):
 
     __ignore_keys__ = CDS_IGNORE_FIELDS
 
-    _default_fields = {"_migration": {**get_helper_dict()}}
+    _default_fields = {"_migration": {
+        **get_helper_dict(record_type="document")}
+    }
 
     def do(
         self,

--- a/cds_ils/importer/providers/cds/rules/base.py
+++ b/cds_ils/importer/providers/cds/rules/base.py
@@ -45,7 +45,10 @@ def recid(self, key, value):
 @model.over("agency_code", "^003")
 def agency_code(self, key, value):
     """Control number identifier."""
-    return value
+    if isinstance(value, str):
+        return value
+    else:
+        raise IgnoreKey("agency_code")
 
 
 @model.over("created_by", "^859__")

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -11,7 +11,7 @@ set -e
 script_path=$(dirname "$0")
 
 # Install application code and entrypoints from 'setup.py'
-pip install --use-deprecated=legacy-resolver -e $script_path/..[all]
+pip install -e $script_path/..[all]
 # Build assets
 invenio collect -v
 invenio webpack buildall

--- a/tests/migrator/test_books.py
+++ b/tests/migrator/test_books.py
@@ -40,12 +40,12 @@ marcxml = (
 def check_transformation(marcxml_body, json_body):
     """Check transformation."""
     blob = create_record(marcxml.format(marcxml_body))
-    model._default_fields = {"_migration": {**get_helper_dict()}}
+    model._default_fields = {"_migration": {**get_helper_dict(record_type="document")}}
 
     record = model.do(blob, ignore_missing=False)
 
     expected = {
-        "_migration": {**get_helper_dict()},
+        "_migration": {**get_helper_dict(record_type="document")},
     }
 
     expected.update(**json_body)
@@ -382,7 +382,7 @@ def test_serial(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "has_serial": True,
                     "serials": [{"title": "DESIGN REPORT",
                                  "volume": None,
@@ -468,7 +468,7 @@ def test_document_type(app):
                 """,
                 {
                      "_migration": {
-                        **get_helper_dict(),
+                        **get_helper_dict(record_type="document"),
                         "tags": ["ENGLISH_BOOK_CLUB"],
                      },
                      "document_type": "BOOK"
@@ -527,7 +527,7 @@ def test_urls(app):
         """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_has_files": True,
                     "eitems_file_links": [
                         {
@@ -546,7 +546,7 @@ def test_urls(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_has_files": True,
                     "eitems_file_links": [
                         {
@@ -588,7 +588,7 @@ def test_urls(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_has_ebl": True,
                     "eitems_ebl": [
                         {
@@ -607,7 +607,7 @@ def test_urls(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_has_external": True,
                     "eitems_external": [
                         {
@@ -628,7 +628,7 @@ def test_urls(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_has_proxy": True,
                     "eitems_proxy": [
                         {
@@ -655,7 +655,7 @@ def test_urls(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_has_ebl": True,
                     "eitems_ebl": [
                         {
@@ -979,7 +979,7 @@ def test_publication_info(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "related": [
                         {"related_recid": "2155631", "relation_type": "other",
                          "relation_description": "chapter of"}],
@@ -1022,7 +1022,7 @@ def test_publication_info(app):
                 ],
                 "document_type": "PERIODICAL_ISSUE",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "has_journal": True,
                     "journal_record_legacy_recids": [
                         {"recid": "123456", "volume": None}
@@ -1141,7 +1141,7 @@ def test_related_record(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "has_related": True,
                     "related": [
                         {
@@ -1163,7 +1163,7 @@ def test_related_record(app):
                 """,
                 {
                     "_migration": {
-                        **get_helper_dict(),
+                        **get_helper_dict(record_type="document"),
                         "has_related": True,
                         "related": [
                             {
@@ -1186,7 +1186,7 @@ def test_related_record(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "has_related": True,
                     "related": [
                         {
@@ -2654,7 +2654,7 @@ def test_book_series(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "serials": [
                         {"title": "Minutes", "issn": None, "volume": None}
                     ],
@@ -2673,7 +2673,7 @@ def test_book_series(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "serials": [
                         {
                             "title": "De Gruyter studies in mathematical physics",
@@ -2695,7 +2695,7 @@ def test_book_series(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "serials": [
                         {
                             "title": "Springer tracts in modern physics",
@@ -2883,7 +2883,7 @@ def test_volume_barcodes(app):
             dict(
                 title="Mathematische Methoden der Physik",
                 _migration={
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     **dict(
                         volumes=[
                             dict(barcode="80-1209-8", volume="1"),
@@ -2931,7 +2931,7 @@ def test_open_access(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "eitems_open_access": True,
                 },
             },
@@ -3034,7 +3034,7 @@ def test_record(app):
             {
                 "_created": "2021-01-04",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     'has_serial': True,
                     'serials': [
                         {
@@ -3144,7 +3144,7 @@ def test_medium(app):
                 """,
                 {
                     "_migration": {
-                        **get_helper_dict(),
+                        **get_helper_dict(record_type="document"),
                     },
                 },
             )
@@ -3157,7 +3157,7 @@ def test_medium(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "item_medium": [
                         {
                             "barcode": "CM-B00065102",
@@ -3177,7 +3177,7 @@ def test_medium(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "item_medium": [
                         {
                             "barcode": "CM-B00062302",
@@ -3197,7 +3197,7 @@ def test_medium(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "item_medium": [
                         {
                             "barcode": "CM-B00063302",
@@ -3222,7 +3222,7 @@ def test_medium(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "item_medium": [
                         {
                             "barcode": "CM-P00096545",

--- a/tests/migrator/test_series.py
+++ b/tests/migrator/test_series.py
@@ -146,7 +146,7 @@ def test_monograph(app):
                 "mode_of_issuance": "MULTIPART_MONOGRAPH",
                 "number_of_volumes": "2",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "volumes": [
                         {
@@ -189,7 +189,7 @@ def test_monograph(app):
                 "mode_of_issuance": "MULTIPART_MONOGRAPH",
                 "number_of_volumes": "2",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "is_multipart": True,
                     "record_type": "multipart",
                     "volumes": [
@@ -227,7 +227,7 @@ def test_monograph(app):
                 ],
                 "mode_of_issuance": "MULTIPART_MONOGRAPH",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "is_multipart": True,
                     "record_type": "multipart",
                     "volumes": [
@@ -265,7 +265,7 @@ def test_monograph(app):
                 ],
                 "mode_of_issuance": "MULTIPART_MONOGRAPH",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "is_multipart": True,
                     "record_type": "multipart",
                     "volumes": [
@@ -309,7 +309,7 @@ def test_monograph(app):
                     "mode_of_issuance": "MULTIPART_MONOGRAPH",
                     "number_of_volumes": "2",
                     "_migration": {
-                        **get_helper_dict(),
+                        **get_helper_dict(record_type="document"),
                         "is_multipart": False,
                         "record_type": "multipart",
                         "volumes": [],
@@ -340,7 +340,7 @@ def test_monograph(app):
                     "mode_of_issuance": "MULTIPART_MONOGRAPH",
                     "number_of_volumes": "2",
                     "_migration": {
-                        **get_helper_dict(),
+                        **get_helper_dict(record_type="document"),
                         "is_multipart": True,
                         "record_type": "multipart",
                         "volumes": [],
@@ -403,7 +403,7 @@ def test_monograph_migration(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "volumes_identifiers": [
                         {
                             "volume": "3",
@@ -479,7 +479,7 @@ def test_monograph_invalid_volume_migration(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "volumes_identifiers": [
                         {
@@ -524,7 +524,7 @@ def test_monograph_volume_migration_no_description(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "volumes_identifiers": [
                         {
@@ -585,7 +585,7 @@ def test_monograph_with_electronic_isbns(app):
                 ],
                 "mode_of_issuance": "MULTIPART_MONOGRAPH",
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "volumes_identifiers": [
                         {
@@ -632,7 +632,7 @@ def test_monograph_volume_migration_doi(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "volumes_identifiers": [
                         {
@@ -661,7 +661,7 @@ def test_monograph_volume_barcode(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "items": [{"barcode": "73-0089-0", "volume": "A"}],
                 },
@@ -683,7 +683,7 @@ def test_monograph_volume_url(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "volumes_urls": [
                         {
@@ -713,7 +713,7 @@ def test_monograph_legacy_representation(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                     "multipart_id": "Vol965",
                     "multivolume_record": False,
@@ -735,7 +735,7 @@ def test_monograph_legacy_report_number(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                 },
                 "mode_of_issuance": "MULTIPART_MONOGRAPH",
@@ -764,7 +764,7 @@ def test_monograph_series_authors(app):
             """,
             {
                 "_migration": {
-                    **get_helper_dict(),
+                    **get_helper_dict(record_type="document"),
                     "record_type": "multipart",
                 },
                 "authors": [

--- a/tests/migrator/test_standard.py
+++ b/tests/migrator/test_standard.py
@@ -21,10 +21,12 @@ marcxml = (
 
 def check_transformation(marcxml_body, json_body):
     blob = create_record(marcxml.format(marcxml_body))
-    model._default_fields = {"_migration": {**get_helper_dict()}}
+    model._default_fields = {
+        "_migration": {**get_helper_dict(record_type="document")}
+    }
 
     record = model.do(blob, ignore_missing=False)
-    expected = {"_migration": {**get_helper_dict()}}
+    expected = {"_migration": {**get_helper_dict(record_type="document")}}
     expected.update(**json_body)
     assert record == expected
 


### PR DESCRIPTION
* Adds ignore rule for document type
* Fixes agency_code bug, it was preventing the records indexing
* Fixes _migration bug, there where some missing fields who caused 'NoneType' error
* closes #https://github.com/CERNDocumentServer/cds-ils/issues/308

ignored rules requested in https://cernbox.cern.ch/index.php/apps/onlyoffice/edit/__myprojects/digital-repositories/Services_Projects/CDS/CDS-ILS/CDS%20-%20Library%20shared/missing-rules-values-journals.xlsx