### PR TITLE
ES: replaces execute()

### DIFF
--- a/cds_ils/cli.py
+++ b/cds_ils/cli.py
@@ -316,10 +316,8 @@ def create_demo_docs(docs_path):
 
 def get_pids(search):
     """Get a list of pids of the search results."""
-    s = search()
-    results = s.execute()
     pids = []
-    for hit in results.hits:
+    for hit in search().scan():
         pids.append(hit["pid"])
 
     return pids

--- a/cds_ils/importer/series/importer.py
+++ b/cds_ils/importer/series/importer.py
@@ -131,9 +131,8 @@ class SeriesImporter(object):
 
         if title:
             search = search_series_by_title(title)
-            results = search.execute().hits
             matches += [
-                x.pid for x in results
+                x.pid for x in search.scan()
                 if x.pid not in matches and x.title == title
             ]
 

--- a/cds_ils/patrons/serializers.py
+++ b/cds_ils/patrons/serializers.py
@@ -47,15 +47,15 @@ def patron_loans_to_dict(patron_loans):
     :return: dict from patron's loan.
     :rtype: dict
     """
-    literatures_on_loan_results = patron_loans["active_loans"].hits.hits
+    literatures_on_loan_results = patron_loans["active_loans"].scan()
     literatures_on_loan = [
-        serialize_on_loan_literature_info(loan["_source"])
+        serialize_on_loan_literature_info(loan)
         for loan in literatures_on_loan_results
     ]
 
-    loan_requests_results = patron_loans["pending_loans"].hits.hits
+    loan_requests_results = patron_loans["pending_loans"].scan()
     loan_requests = [
-        serialize_loan_request_literature_info(loan["_source"])
+        serialize_loan_request_literature_info(loan)
         for loan in loan_requests_results
     ]
 

--- a/cds_ils/patrons/views.py
+++ b/cds_ils/patrons/views.py
@@ -69,12 +69,11 @@ class PatronLoansResource(ContentNegotiatedMethodView):
         ]
         active_loans = search_by_patron_item_or_document(
             patron["id"], filter_states=active_loan_states
-        ).execute()
-
+        )
         pending_loan_states = ["PENDING"]
         pending_loans = search_by_patron_item_or_document(
             patron["id"], filter_states=pending_loan_states
-        ).execute()
+        )
 
         patron_loans = {
             "active_loans": active_loans,


### PR DESCRIPTION
* Replaces execute() from ES querys capable of
  returning more than 10 hits with scan()
* closes https://github.com/inveniosoftware/invenio-app-ils/issues/1048