### PR TITLE
rules: conference and alternative_title

### DIFF
--- a/cds_ils/importer/providers/cds/ignore_fields.py
+++ b/cds_ils/importer/providers/cds/ignore_fields.py
@@ -50,6 +50,9 @@ CDS_IGNORE_FIELDS = {
     "269__a",  # preprint info
     "269__b",  # preprint info
     "269__c",  # preprint date
+    "270__a",
+    "270__k"
+    "270__l",
     "270__m",  # conference email
     "300__b",  # 206 cds-dojson
     "440_3a",  # 206 cds-dojson

--- a/cds_ils/importer/providers/cds/models/journal.py
+++ b/cds_ils/importer/providers/cds/models/journal.py
@@ -83,6 +83,9 @@ class CDSJournal(CdsIlsOverdo):
         "222__b",
         "340__z",
         "697C_a",
+        "8564_z",
+        "939__y",
+        "2463_a",
     }
 
     __ignore_keys__ = CDS_IGNORE_FIELDS | __model_ignore_keys__

--- a/cds_ils/importer/providers/cds/rules/base.py
+++ b/cds_ils/importer/providers/cds/rules/base.py
@@ -889,6 +889,7 @@ def conference_info(self, key, value):
             ],
             "series": str(series_number),
             "country": country_code or "None",
+            "acronym": clean_val("x", v, str),
         }
 
     _conference_info = self.get("conference_info", [])
@@ -906,7 +907,15 @@ def conference_info(self, key, value):
         else:
             if "a" in value and "x" not in value and len(value) > 2:
                 _conference_info.append(clean_conference_info_fields(v, False))
-
+            elif "a" in value and len(value) == 2:
+                _alternative_titles = self.get("alternative_titles", [])
+                _alternative_titles.append(
+                    {
+                        "value": clean_val("a", v, str, req=True),
+                        "type": "ALTERNATIVE_TITLE",
+                    }
+                )
+                self["alternative_titles"] = _alternative_titles
     return _conference_info
 
 

--- a/tests/migrator/rules/test_books.py
+++ b/tests/migrator/rules/test_books.py
@@ -2500,6 +2500,55 @@ def test_conference_info(app):
                  between Astrophysics and Astroparticle Physics""",
                     "conference_place": "Bari, Italy",
                 },
+                "alternative_titles": [
+                    {
+                        "value": "SNGHEGE2004",
+                        "type": "ALTERNATIVE_TITLE",
+                    }
+                ]
+            },
+        )
+        check_transformation(
+            """
+            <datafield tag="111" ind1=" " ind2=" ">
+                <subfield code="9">20040621</subfield>
+                <subfield code="a">2nd Workshop on Science with
+                 the New Generation of High Energy Gamma-ray Experiments:
+                 between Astrophysics and Astroparticle Physics
+                </subfield>
+                <subfield code="c">Bari, Italy</subfield>
+                <subfield code="d">21 Jun 2004</subfield>
+                <subfield code="f">2004</subfield>
+                <subfield code="g">bari20040621</subfield>
+                <subfield code="n">2</subfield>
+                <subfield code="x">SNGHEGE2004</subfield>
+                <subfield code="w">IT</subfield>
+                <subfield code="z">20040621</subfield>
+            </datafield>
+            """,
+            {
+                "_migration": {
+                    **get_helper_dict(record_type="document"),
+                    "conference_title": """2nd Workshop on Science with
+                 the New Generation of High Energy Gamma-ray Experiments:
+                 between Astrophysics and Astroparticle Physics""",
+                    "conference_place": "Bari, Italy",
+                },
+                "conference_info": [
+                    {
+                    "identifiers": [
+                        {"scheme": "CERN_CODE", "value": "bari20040621"},
+                    ],
+                    "title": """2nd Workshop on Science with
+                 the New Generation of High Energy Gamma-ray Experiments:
+                 between Astrophysics and Astroparticle Physics""",
+                    "place": "Bari, Italy",
+                    "dates": "2004-06-21 - 2004-06-21",
+                    "series": "2",
+                    "country": "IT",
+                    "acronym": "SNGHEGE2004",
+                }
+                ]
             },
         )
         with pytest.raises(UnexpectedValue):


### PR DESCRIPTION
* Adds constraints for conference rule
* Blocked by https://github.com/CERNDocumentServer/cds-ils/pull/375
* closes https://github.com/CERNDocumentServer/cds-migrator-kit/issues/80
* closes https://github.com/CERNDocumentServer/cds-migrator-kit/issues/65