### PR TITLE
ui: display standard number in an prominent place

### DIFF
--- a/ui/src/Importer/ImporterTaskDetails/ImportedDocuments.js
+++ b/ui/src/Importer/ImporterTaskDetails/ImportedDocuments.js
@@ -145,7 +145,6 @@ export class ImportedDocuments extends React.Component {
               ? elem.created_document
               : elem.updated_document
             : null;
-          console.log(document);
           return (
             <div key={elem.index}>
               <Accordion.Title

--- a/ui/src/overridableMapping.js
+++ b/ui/src/overridableMapping.js
@@ -12,6 +12,7 @@ import {
 import { DocumentRequestFormFields } from './overridden/frontsite/DocumentRequest/DocumentRequestForm';
 import { DocumentRequestFormHeader } from './overridden/frontsite/DocumentRequest/DocumentRequestFormHeader';
 import { NotAvailable } from './overridden/frontsite/Document/DocumentDetails/DocumentCirculation/NotAvailable';
+import { StandardNumber } from './overridden/frontsite/Document/DocumentDetails/DocumentPanel/StandardNumber';
 import {
   HomeContent,
   HomeHeadline,
@@ -36,6 +37,8 @@ export const overriddenCmps = {
   'FrontSite.CustomRoute': LegacyRecordRoute,
   DocumentRequestForm: DocumentRequestFormFields,
   'DocumentRequestForm.header': DocumentRequestFormHeader,
+  'DocumentPanel.AfterAuthors': StandardNumber,
+  'DocumentPanelMobile.AfterAuthors': StandardNumber,
   'BackOfficeRoutesSwitch.CustomRoute': ImporterRoute,
   'Backoffice.Sidebar.CustomMenuItem': SideBarMenuItem,
 };

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentPanel/StandardNumber.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentPanel/StandardNumber.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Label } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import _isEmpty from 'lodash/isEmpty';
+
+export const StandardNumber = ({ metadata, ...props }) => {
+  const renderLabels = numbers => {
+    return numbers.map(number => (
+      <Label
+        className="default-margin-bottom standard-number"
+        color="grey"
+        image
+        key={number}
+      >
+        Standard number
+        <Label.Detail>{number}</Label.Detail>
+      </Label>
+    ));
+  };
+
+  let standardNumbers = [];
+  if (metadata.identifiers) {
+    standardNumbers = metadata.identifiers.filter(
+      sn => sn.scheme === 'STANDARD_NUMBER'
+    );
+    standardNumbers = standardNumbers.map(a => a.value);
+  }
+
+  return _isEmpty(standardNumbers) ? null : (
+    <div>{renderLabels(standardNumbers)}</div>
+  );
+};
+
+StandardNumber.propTypes = {
+  metadata: PropTypes.object.isRequired,
+};

--- a/ui/src/semantic-ui/site/elements/label.overrides
+++ b/ui/src/semantic-ui/site/elements/label.overrides
@@ -1,3 +1,10 @@
 /*******************************
          Site Overrides
 *******************************/
+
+/* Frontsite */
+@{fs-parent-selector} {
+    .standard-number {
+        margin-left: 0;
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/inveniosoftware/react-invenio-app-ils/pull/410

<img width="690" alt="Screenshot 2021-03-17 at 14 31 20" src="https://user-images.githubusercontent.com/33685068/111475580-86379600-872d-11eb-9312-0a75d7a53ee1.png">

Multiple values that don't fit in the same line:
<img width="685" alt="Screenshot 2021-03-17 at 15 43 19" src="https://user-images.githubusercontent.com/33685068/111486165-8b99de00-8737-11eb-8ced-85f35bec37e2.png">


Multiple values that fit in the same line:
<img width="693" alt="Screenshot 2021-03-17 at 15 41 22" src="https://user-images.githubusercontent.com/33685068/111486033-6c02b580-8737-11eb-8f53-17ecf5a5d3b7.png">


Mobile:
<img width="460" alt="Screenshot 2021-03-17 at 14 31 37" src="https://user-images.githubusercontent.com/33685068/111475575-83d53c00-872d-11eb-9da2-ad52ecc5cbd7.png">

<img width="447" alt="Screenshot 2021-03-17 at 15 43 29" src="https://user-images.githubusercontent.com/33685068/111486249-9e141780-8737-11eb-9c84-3002617a62fb.png">


<img width="452" alt="Screenshot 2021-03-17 at 15 41 38" src="https://user-images.githubusercontent.com/33685068/111486049-6f963c80-8737-11eb-93e9-92b524e1a339.png">
