### PR TITLE
migration: standards

### DIFF
--- a/cds_ils/importer/providers/cds/ignore_fields.py
+++ b/cds_ils/importer/providers/cds/ignore_fields.py
@@ -120,6 +120,7 @@ CDS_IGNORE_FIELDS = {
     "961__h",
     "961__l",
     "961__x",
+    "962__k",
     "962__b",
     "962__n",  # books connected by conference
     "963__a",

--- a/cds_ils/importer/providers/cds/rules/base.py
+++ b/cds_ils/importer/providers/cds/rules/base.py
@@ -378,36 +378,6 @@ def standard_review(self, key, value):
     return _extensions
 
 
-@model.over("publication_info", "^962__")
-def publication_additional(self, key, value):
-    """Translates additional publication info & other related_records field."""
-    _publication_info = self.get("publication_info", [])
-    _migration = self["_migration"]
-    _related = _migration["related"]
-    empty = not bool(_publication_info)
-    for i, v in enumerate(force_list(value)):
-        temp_info = {}
-        pages = clean_val("k", v, str)
-        if pages:
-            temp_info.update(pages=pages)
-        rel_recid = clean_val("b", v, str)
-        if rel_recid:
-            _related.append(
-                {
-                    "related_recid": rel_recid,
-                    "relation_type": OTHER_RELATION.name,
-                    "relation_description": "is chapter of"
-                }
-            )
-            _migration.update({"related": _related, "has_related": True})
-        if not empty and i < len(_publication_info):
-            _publication_info[i].update(temp_info)
-        else:
-            _publication_info.append(temp_info)
-
-    return _publication_info
-
-
 @model.over("_migration", "(^775__)|(^787__)")
 @out_strip
 def related_records(self, key, value):

--- a/cds_ils/importer/providers/cds/rules/standard.py
+++ b/cds_ils/importer/providers/cds/rules/standard.py
@@ -10,6 +10,8 @@
 from __future__ import unicode_literals
 
 from dojson.errors import IgnoreKey
+from dojson.utils import force_list
+from invenio_app_ils.relations.api import OTHER_RELATION
 
 from cds_ils.importer.errors import UnexpectedValue
 from cds_ils.importer.providers.cds.models.standard import model
@@ -73,3 +75,33 @@ def title(self, key, value):
         )
         self["alternative_titles"] = _alternative_titles
     return clean_val("a", value, str, req=True)
+
+
+@model.over("publication_info", "^962__")
+def publication_additional(self, key, value):
+    """Translates additional publication info & other related_records field."""
+    _publication_info = self.get("publication_info", [])
+    _migration = self["_migration"]
+    _related = _migration["related"]
+    empty = not bool(_publication_info)
+    for i, v in enumerate(force_list(value)):
+        temp_info = {}
+        pages = clean_val("k", v, str)
+        if pages:
+            temp_info.update(pages=pages)
+        rel_recid = clean_val("b", v, str)
+        if rel_recid:
+            _related.append(
+                {
+                    "related_recid": rel_recid,
+                    "relation_type": OTHER_RELATION.name,
+                    "relation_description": "is chapter of"
+                }
+            )
+            _migration.update({"related": _related, "has_related": True})
+        if not empty and i < len(_publication_info):
+            _publication_info[i].update(temp_info)
+        else:
+            _publication_info.append(temp_info)
+
+    return _publication_info

--- a/tests/migrator/rules/test_books.py
+++ b/tests/migrator/rules/test_books.py
@@ -940,9 +940,6 @@ def test_publication_info(app):
                 <subfield code="v">42</subfield>
                 <subfield code="w">C19-01-08.1</subfield>
             </datafield>
-            <datafield tag="962" ind1=" " ind2=" ">
-                <subfield code="n">BOOK</subfield>
-            </datafield>
             """,
             {
                 "publication_info": [
@@ -964,9 +961,6 @@ def test_publication_info(app):
                 <subfield code="y">2007</subfield>
                 <subfield code="p">Radiat. Meas.</subfield>
                 <subfield code="v">42</subfield>
-            </datafield>
-            <datafield tag="962" ind1=" " ind2=" ">
-                <subfield code="n">fsihfifri</subfield>
             </datafield>
             """,
             {
@@ -996,33 +990,6 @@ def test_publication_info(app):
                 "publication_info": [
                     {"note": "1692 numebrs text etc Random text"}
                 ]
-            },
-        )
-        check_transformation(
-            """
-            <datafield tag="962" ind1=" " ind2=" ">
-                <subfield code="b">2155631</subfield>
-                <subfield code="n">genoa20160330</subfield>
-                <subfield code="k">1</subfield>
-            </datafield>
-            """,
-            {
-                "_migration": {
-                    **get_helper_dict(record_type="document"),
-                    "related": [
-                        {
-                            "related_recid": "2155631",
-                            "relation_type": "other",
-                            "relation_description": "is chapter of"
-                        }
-                    ],
-                    "has_related": True,
-                },
-                "publication_info": [
-                    {
-                        "pages": '1',
-                    }
-                ],
             },
         )
         check_transformation(

--- a/tests/migrator/rules/test_standard.py
+++ b/tests/migrator/rules/test_standard.py
@@ -156,3 +156,35 @@ def test_title(app):
                 ],
             },
         )
+
+
+def test_publication_info(app):
+    """Test publication info."""
+    with app.app_context():
+        check_transformation(
+            """
+            <datafield tag="962" ind1=" " ind2=" ">
+                <subfield code="b">2155631</subfield>
+                <subfield code="n">genoa20160330</subfield>
+                <subfield code="k">1</subfield>
+            </datafield>
+            """,
+            {
+                "_migration": {
+                    **get_helper_dict(record_type="document"),
+                    "related": [
+                        {
+                            "related_recid": "2155631",
+                            "relation_type": "other",
+                            "relation_description": "is chapter of"
+                        }
+                    ],
+                    "has_related": True,
+                },
+                "publication_info": [
+                    {
+                        "pages": '1',
+                    }
+                ],
+            },
+        )


### PR DESCRIPTION
* Ignores field 962__ except for standards
* closes https://github.com/CERNDocumentServer/cds-migrator-kit/issues/88