### PR TITLE
[BLOCKED]ui: display standard number in search results

### DIFF
--- a/ui/src/overridableMapping.js
+++ b/ui/src/overridableMapping.js
@@ -21,6 +21,8 @@ import { LegacyRecordRoute } from './overridden/frontsite/Routes/LegacyRoute';
 import { Slogan } from './overridden/frontsite/Home/Slogan';
 import { SideBarMenuItem } from './overridden/backoffice/Sidebar/SideBarMenuItem';
 import { ImporterRoute } from './overridden/routes/ImporterRoute';
+import { overriddenSearchAppCmps } from './overridden/frontsite/LiteratureSearch/LiteratureSearch';
+import { StandardCardView } from './overridden/frontsite//DocumentSearch/StandardCardView';
 
 export const overriddenCmps = {
   'Backoffice.PatronDetails.Metadata': PatronMetadata,
@@ -39,6 +41,8 @@ export const overriddenCmps = {
   'DocumentRequestForm.header': DocumentRequestFormHeader,
   'DocumentPanel.AfterAuthors': StandardNumber,
   'DocumentPanelMobile.AfterAuthors': StandardNumber,
+  'DocumentCard.AfterAuthors': StandardCardView,
+  LiteratureSearch: overriddenSearchAppCmps,
   'BackOfficeRoutesSwitch.CustomRoute': ImporterRoute,
   'Backoffice.Sidebar.CustomMenuItem': SideBarMenuItem,
 };

--- a/ui/src/overridden/frontsite/DocumentSearch/StandardCardView.js
+++ b/ui/src/overridden/frontsite/DocumentSearch/StandardCardView.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Label } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+export const StandardCardView = ({ metadata, ...props }) => {
+  const first = metadata.identifiers
+    ? metadata.identifiers
+        .filter(sn => sn.scheme === 'STANDARD_NUMBER')
+        .map(a => a.value)
+        .shift()
+    : null;
+
+  return first ? (
+    <div>
+      <Label
+        basic
+        size="small"
+        color="grey"
+        className="margin-bottom-with-standard-number"
+      >
+        {first}
+      </Label>
+    </div>
+  ) : null;
+};
+
+StandardCardView.propTypes = {
+  metadata: PropTypes.object.isRequired,
+};

--- a/ui/src/overridden/frontsite/DocumentSearch/StandardListView.js
+++ b/ui/src/overridden/frontsite/DocumentSearch/StandardListView.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Label } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+export const StandardListView = ({ metadata, ...props }) => {
+  const renderLabels = numbers => {
+    return numbers.map(number => (
+      <Label
+        className="standard-number-list-view"
+        color="grey"
+        image
+        size="small"
+        key={number}
+      >
+        Standard number
+        <Label.Detail>{number}</Label.Detail>
+      </Label>
+    ));
+  };
+
+  const standardNumbers = metadata.identifiers
+    ? metadata.identifiers
+        .filter(sn => sn.scheme === 'STANDARD_NUMBER')
+        .map(a => a.value)
+    : null;
+
+  return standardNumbers ? <div>{renderLabels(standardNumbers)}</div> : null;
+};
+
+StandardListView.propTypes = {
+  metadata: PropTypes.object.isRequired,
+};

--- a/ui/src/overridden/frontsite/LiteratureSearch/LiteratureSearch.js
+++ b/ui/src/overridden/frontsite/LiteratureSearch/LiteratureSearch.js
@@ -1,0 +1,11 @@
+import { parametrize } from 'react-overridable';
+import { LiteratureSearch } from '@inveniosoftware/react-invenio-app-ils';
+import { StandardListView } from '../DocumentSearch/StandardListView';
+import { StandardCardView } from '../DocumentSearch/StandardCardView';
+
+export const overriddenSearchAppCmps = parametrize(LiteratureSearch, {
+  overriddenSearchAppCmps: {
+    'DocumentListEntry.BeforeAuthors': StandardListView,
+    'DocumentCard.AfterAuthors': StandardCardView,
+  },
+});

--- a/ui/src/semantic-ui/site/elements/label.overrides
+++ b/ui/src/semantic-ui/site/elements/label.overrides
@@ -7,4 +7,13 @@
     .standard-number {
         margin-left: 0;
     }
+
+    .standard-number-list-view {
+        float: right;
+        margin-right: @defaultMarginValue !important;
+    }
+
+    .margin-bottom-with-standard-number {
+        margin-bottom: @defaultMarginValue * 0.5 !important;
+    }
 }


### PR DESCRIPTION
Depends on https://github.com/inveniosoftware/react-invenio-app-ils/pull/417

- display standard number in card and list view search results

### Screenshots
List view
<img width="1390" alt="Screenshot 2021-03-23 at 11 19 21" src="https://user-images.githubusercontent.com/33685068/112132373-d3eb4d00-8bca-11eb-920d-0f6d574774b2.png">
Card view (display only first standard number if multiple)
<img width="181" alt="Screenshot 2021-03-23 at 11 27 54" src="https://user-images.githubusercontent.com/33685068/112132459-f1201b80-8bca-11eb-990f-2f0b57a33977.png">

