### PR TITLE
Import Documents: statistics and filtering

### DIFF
--- a/ui/src/importer/ImporterList.js
+++ b/ui/src/importer/ImporterList.js
@@ -15,28 +15,24 @@ export const modeFormatter = mode => {
     case 'IMPORT':
       return (
         <Label color="blue" basic>
-          <Icon name="plus" />
           Import
         </Label>
       );
     case 'DELETE':
       return (
         <Label color="red" basic>
-          <Icon name="minus" />
           Delete
         </Label>
       );
     case 'PREVIEW_IMPORT':
       return (
         <Label color="teal" basic>
-          <Icon name="plus" />
           Preview (import)
         </Label>
       );
     case 'PREVIEW_DELETE':
       return (
         <Label color="teal" basic>
-          <Icon name="plus" />
           Preview (delete)
         </Label>
       );

--- a/ui/src/importer/importerTaskDetails/ImportedTable.js
+++ b/ui/src/importer/importerTaskDetails/ImportedTable.js
@@ -13,18 +13,17 @@ export class ImportedTable extends React.Component {
     this.pageSize = 100;
     this.state = {
       activePage: 1,
-      records: this.props.records,
     };
   }
 
-  static getDerivedStateFromProps(props, state) {
-    if (state.records.length != props.records.length) {
-      return {
-        activePage: 1,
-        records: props.records,
-      };
+  componentDidUpdate(prevProps) {
+    const { records } = this.props;
+    if (prevProps.records !== records) {
+      this.resetPage();
     }
   }
+
+  resetPage = () => this.setState({ activePage: 1 });
 
   handlePaginationChange = (e, { activePage }) => this.setState({ activePage });
 

--- a/ui/src/importer/importerTaskDetails/ImportedTable.js
+++ b/ui/src/importer/importerTaskDetails/ImportedTable.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Pagination, Table } from 'semantic-ui-react';
+import _isEmpty from 'lodash/isEmpty';
+import { EitemImportDetailsModal } from '../EitemImportDetailsModal';
+import { SeriesImportDetailsModal } from '../SeriesImportDetailsModal';
+import { JsonViewModal } from '../JsonViewModal';
+import { ImportedDocumentReport } from './ImportedDocumentReport';
+
+export class ImportedTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.pageSize = 100;
+    this.state = {
+      activePage: 1,
+      records: this.props.records,
+    };
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    if (state.records.length != props.records.length) {
+      return {
+        activePage: 1,
+        records: props.records,
+      };
+    }
+  }
+
+  handlePaginationChange = (e, { activePage }) => this.setState({ activePage });
+
+  render() {
+    const { records } = this.props;
+    const { activePage } = this.state;
+    return (
+      <>
+        <Table styled="true" fluid="true" striped celled structured width={16}>
+          <Table.Header className="sticky-table-header">
+            <Table.Row>
+              <Table.HeaderCell collapsing rowSpan="3" textAlign="center">
+                No
+              </Table.HeaderCell>
+              <Table.HeaderCell width="5" rowSpan="3">
+                Title [Provider recid]
+              </Table.HeaderCell>
+
+              <Table.HeaderCell collapsing rowSpan="3">
+                Action
+              </Table.HeaderCell>
+              <Table.HeaderCell collapsing rowSpan="3">
+                Output document
+              </Table.HeaderCell>
+              <Table.HeaderCell collapsing colSpan="4">
+                Dependent records
+              </Table.HeaderCell>
+              <Table.HeaderCell collapsing rowSpan="3">
+                Partial matches
+              </Table.HeaderCell>
+              <Table.HeaderCell collapsing rowSpan="3">
+                Error
+              </Table.HeaderCell>
+            </Table.Row>
+            <Table.Row>
+              <Table.HeaderCell collapsing colSpan="2">
+                E-item
+              </Table.HeaderCell>
+              <Table.HeaderCell collapsing colSpan="2">
+                Serials
+              </Table.HeaderCell>
+            </Table.Row>
+            <Table.Row>
+              <Table.HeaderCell collapsing>Detected</Table.HeaderCell>
+              <Table.HeaderCell collapsing>Action and details</Table.HeaderCell>
+              <Table.HeaderCell collapsing>Detected</Table.HeaderCell>
+              <Table.HeaderCell collapsing>Details</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {records
+              .slice(
+                activePage * this.pageSize - this.pageSize,
+                activePage * this.pageSize
+              )
+              .map((elem, index) => {
+                return (
+                  !_isEmpty(elem) && (
+                    <ImportedDocumentReport
+                      // Keep the index as key due to lack of other unique id.
+                      key={index}
+                      documentReport={elem}
+                      listIndex={index + (activePage - 1) * this.pageSize + 1}
+                    />
+                  )
+                );
+              })}
+          </Table.Body>
+
+          <Table.Footer>
+            <Table.Row>
+              <Table.HeaderCell colSpan="10">
+                <Pagination
+                  defaultActivePage={1}
+                  totalPages={Math.ceil(records.length / this.pageSize)}
+                  activePage={activePage}
+                  onPageChange={this.handlePaginationChange}
+                  floated="right"
+                />
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Footer>
+        </Table>
+        <JsonViewModal />
+        <SeriesImportDetailsModal />
+        <EitemImportDetailsModal />
+      </>
+    );
+  }
+}
+
+ImportedTable.propTypes = {
+  records: PropTypes.object.isRequired,
+};

--- a/ui/src/importer/importerTaskDetails/cancelImportTask.js
+++ b/ui/src/importer/importerTaskDetails/cancelImportTask.js
@@ -80,15 +80,12 @@ export class CancelImportTask extends Component {
           open={modalOpen}
           onCancel={this.handleCloseModal}
           onConfirm={this.handleCancelImportAction}
-          content={
-            <>
-              You are about to cancel current import - the cancel will be
-              performed after the current record is processed.
-              <strong>Are you sure you want to proceed?</strong>
-            </>
-          }
+          header="Import cancel."
+          content="You are about to cancel current import - the cancel will be
+          performed after the current record is processed.
+          Are you sure you want to proceed?"
           loading={cancelLoading}
-        />{' '}
+        />
       </>
     );
   }

--- a/ui/src/semantic-ui/site/views/statistic.overrides
+++ b/ui/src/semantic-ui/site/views/statistic.overrides
@@ -1,3 +1,18 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+.ui.statistic.import-statistic{
+    margin-right: 15px !important;
+    border-radius: 10px;
+    padding: 20px 10px;
+    cursor: pointer;
+}
+
+.ui.statistic.import-statistic:hover{
+    box-shadow: 0 2px 8px #bbb;
+}
+
+.ui.statistic.statistic-selected{
+    box-shadow: 0 0 0 1px #d4d4d5,0 2px 0 0 #21ba45,0 1px 3px 0 #d4d4d5 !important;
+}


### PR DESCRIPTION
Display statistics during and after an import process of the imported records.
The displayed statistics are: records imported, records to be imported, records created, records updated, records with errors, records with eItem, records with serials.
Add the possibility for the user to filter the importer results table based on the different criteria displayed on the statistics fields.
closes https://github.com/CERNDocumentServer/cds-ils/issues/563
part of https://github.com/CERNDocumentServer/cds-ils/pull/599
Default page.
![Screenshot from 2021-09-23 10-17-04](https://user-images.githubusercontent.com/25476209/134475174-01428dfe-2110-4858-af75-db8e755f70e0.png)
Filter by records with serials.
![Screenshot from 2021-09-23 10-17-12](https://user-images.githubusercontent.com/25476209/134475178-4ea0c976-07e7-430c-bb5a-d7150fbfd200.png)
Filter by records with errors.
![Screenshot from 2021-09-23 10-17-25](https://user-images.githubusercontent.com/25476209/134475180-162c87ca-f9e3-484f-8803-c86826874d9b.png)

Previous discussion in this PRs:
https://github.com/CERNDocumentServer/cds-ils/pull/594.
https://github.com/CERNDocumentServer/cds-ils/pull/599
