### PR TITLE
BulkExtend: change email subject 

### DIFF
--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -485,6 +485,7 @@ ILS_RECORDS_METADATA_EXTENSIONS = {
 }
 
 ILS_NOTIFICATIONS_TEMPLATES_CIRCULATION = {
+    "bulk_extend": "cds_bulk_extend.html",
     "cancel": "cds_cancel.html",
     "request": "cds_request.html",
     "request_no_items": "cds_request_no_items.html",

--- a/cds_ils/templates/invenio_app_ils_circulation/notifications/cds_bulk_extend.html
+++ b/cds_ils/templates/invenio_app_ils_circulation/notifications/cds_bulk_extend.html
@@ -1,5 +1,5 @@
 {% block title %}
-InvenioILS: Loans extensions summary"
+CERN Library: Loans extensions summary
 {% endblock %}
 
 {% block body_plain %}


### PR DESCRIPTION
Set the subject of the emails sent when performing a bulk extend.
Fix cds bulk extend template not overwritting ils.
closes: https://github.com/CERNDocumentServer/cds-ils/issues/626