### PR TITLE
Importer: displayed title from raw_json and added title check in addition to isbn check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ install_requires = [
     "pluggy>=0.13.1,<1.0.0",
     # breaking changes in version 4
     "jsonschema>=3.0.0,<4.0.0",
+    # version conflict by invenio-oauth2server
+    "WTForms<3.0.0,>=2.3.3",
+    # invenio-celery conflict fix
+    "celery<5.2,>=5.1.0",
 ]
 
 packages = find_packages()

--- a/ui/src/importer/importerTaskDetails/ImportedDocumentReport.js
+++ b/ui/src/importer/importerTaskDetails/ImportedDocumentReport.js
@@ -35,7 +35,7 @@ class ImportedDocumentReportComponent extends Component {
     if (!_isEmpty(documentReport.document)) {
       let volume = _get(documentReport, 'raw_json._serial[0].volume', '');
       volume = volume ? `(v. ${volume})` : '';
-      title = `${documentReport.document_json.title} ${volume}
+      title = `${documentReport.raw_json.title} ${volume}
       [${documentReport.entry_recid}]`;
     } else {
       title = documentReport.entry_recid;


### PR DESCRIPTION
The title from the parsed XML file is now being used instead of the title of the matched document. Now also checks if the title is equal to the matched document to further prevent wrongful matches 

closes https://github.com/CERNDocumentServer/cds-ils/issues/613