### PR TITLE
Importer: add pagination to imports list

### DIFF
--- a/cds_ils/importer/api.py
+++ b/cds_ils/importer/api.py
@@ -15,9 +15,9 @@ from invenio_app_ils.errors import IlsValidationError, \
 from invenio_db import db
 from invenio_pidstore.errors import PIDDeletedError
 
-from cds_ils.importer.errors import LossyConversion, MissingRequiredField, \
-    ProviderNotAllowedDeletion, RecordModelMissing, RecordNotDeletable, \
-    SeriesImportError, UnexpectedValue, UnknownProvider
+from cds_ils.importer.errors import InvalidProvider, LossyConversion, \
+    MissingRequiredField, ProviderNotAllowedDeletion, RecordModelMissing, \
+    RecordNotDeletable, SeriesImportError, UnexpectedValue, UnknownProvider
 from cds_ils.importer.models import ImporterMode, ImporterTaskStatus, \
     ImportRecordLog
 from cds_ils.importer.parse_xml import get_record_recid_from_xml, \
@@ -99,7 +99,8 @@ def import_from_xml(log, source_path, source_type, provider, mode,
                         ProviderNotAllowedDeletion,
                         SeriesImportError,
                         RecordHasReferencesError, UnknownProvider,
-                        VocabularyError, PIDDeletedError) as e:
+                        VocabularyError, PIDDeletedError,
+                        InvalidProvider) as e:
                     ImportRecordLog.create_failure(
                         log.id, record_recid,
                         str(e.description), report={"raw_json": json_data})

--- a/cds_ils/importer/errors.py
+++ b/cds_ils/importer/errors.py
@@ -113,4 +113,10 @@ class SeriesImportError(CDSImporterException):
 class UnknownProvider(CDSImporterException):
     """Unknown provider exception."""
 
+    message = "Unknown record provider."
+
+
+class InvalidProvider(CDSImporterException):
+    """Invalid provider exception."""
+
     message = "Invalid record provider."

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -191,8 +191,8 @@ export const config = {
   IMPORTER: {
     providers: [
       { key: 'springer', text: 'Springer', value: 'springer' },
-      { key: 'ebl', text: 'EBL', value: 'ebl' },
-      { key: 'safari', text: 'Safari', value: 'safari' },
+      { key: 'ebl', text: 'EbookCentral (EBL)', value: 'ebl' },
+      { key: 'safari', text: "O'reilly (Safari)", value: 'safari' },
     ],
     modes: [
       { key: 'create', text: 'Import', value: 'IMPORT' },

--- a/ui/src/importer/EitemImportDetailsModal/EitemImportDetailsModal.js
+++ b/ui/src/importer/EitemImportDetailsModal/EitemImportDetailsModal.js
@@ -52,3 +52,7 @@ EitemImportDetails.propTypes = {
   open: PropTypes.bool,
   modalClose: PropTypes.func.isRequired,
 };
+
+EitemImportDetails.defaultProps = {
+  open: false,
+};

--- a/ui/src/importer/Importer.js
+++ b/ui/src/importer/Importer.js
@@ -44,9 +44,9 @@ export class Importer extends Component {
     });
   };
 
-  handleCheckboxChange = (e, { name, value }) => {
+  handleCheckboxChange = (e, { name, checked }) => {
     this.setState({
-      [name]: !value,
+      [name]: checked,
     });
   };
 
@@ -233,90 +233,88 @@ export class Importer extends Component {
     } = this.state;
 
     return (
-      <>
-        <Form>
-          <Segment>
-            <Form.Group widths="equal">
-              <Form.Select
-                placeholder="Select a provider ..."
-                label="Provider"
-                search
-                selection
-                name="provider"
-                value={provider}
-                options={invenioConfig.IMPORTER.providers}
-                onChange={this.handleChange}
-                required
-                error={providerMissing ? 'Please enter a provider' : null}
-              />
-              <Form.Select
-                placeholder="Select a mode ..."
-                label="Mode"
-                search
-                selection
-                name="mode"
-                value={mode}
-                options={invenioConfig.IMPORTER.modes}
-                onChange={this.handleChange}
-                required
-                error={modeMissing ? 'Please enter a mode' : null}
-              />
-            </Form.Group>
-            <Form.Group widths="equal">
-              <Form.Checkbox
-                className="default-margin-top"
-                label="Ignore missing import rules"
-                checked={ignoreMissingRules}
-                name="ignoreMissingRules"
-                onChange={this.handleCheckboxChange}
-              />
-              <Form.Field className="default-margin-top">
-                <Button
-                  icon="file"
-                  content="Choose File"
-                  labelPosition="left"
-                  onClick={e => {
-                    e.preventDefault();
-                    this.filesRef.current.click();
-                  }}
-                />
-                <input
-                  hidden
-                  ref={this.filesRef}
-                  id="upload"
-                  type="file"
-                  accept=".xml"
-                  onChange={this.onFileChange}
-                />
-                <Label basic prompt={fileMissing} pointing="left">
-                  {file ? file.name : 'No file selected.'}
-                </Label>
-              </Form.Field>
-            </Form.Group>
-          </Segment>
-          <>
-            <Button
-              primary
-              onClick={() => this.handleSubmit('PREVIEW')}
-              content="Preview"
+      <Form>
+        <Segment>
+          <Form.Group widths="equal">
+            <Form.Select
+              placeholder="Select a provider ..."
+              label="Provider"
+              search
+              selection
+              name="provider"
+              value={provider}
+              options={invenioConfig.IMPORTER.providers}
+              onChange={this.handleChange}
+              required
+              error={providerMissing ? 'Please enter a provider' : null}
             />
-            {mode === 'DELETE' ? (
-              this.renderModal()
-            ) : (
-              <>
-                <Button
-                  secondary
-                  content="Import"
-                  onClick={(e, props) => {
-                    this.handleImportConfirmOpen();
-                  }}
-                />
-                {this.renderImportConfirm()}
-              </>
-            )}
-          </>
-        </Form>
-      </>
+            <Form.Select
+              placeholder="Select a mode ..."
+              label="Mode"
+              search
+              selection
+              name="mode"
+              value={mode}
+              options={invenioConfig.IMPORTER.modes}
+              onChange={this.handleChange}
+              required
+              error={modeMissing ? 'Please enter a mode' : null}
+            />
+          </Form.Group>
+          <Form.Group widths="equal">
+            <Form.Checkbox
+              className="default-margin-top"
+              label="Ignore missing import rules"
+              checked={ignoreMissingRules}
+              name="ignoreMissingRules"
+              onChange={this.handleCheckboxChange}
+            />
+            <Form.Field className="default-margin-top">
+              <Button
+                icon="file"
+                content="Choose File"
+                labelPosition="left"
+                onClick={e => {
+                  e.preventDefault();
+                  this.filesRef.current.click();
+                }}
+              />
+              <input
+                hidden
+                ref={this.filesRef}
+                id="upload"
+                type="file"
+                accept=".xml"
+                onChange={this.onFileChange}
+              />
+              <Label basic prompt={fileMissing} pointing="left">
+                {file ? file.name : 'No file selected.'}
+              </Label>
+            </Form.Field>
+          </Form.Group>
+        </Segment>
+        <>
+          <Button
+            primary
+            onClick={() => this.handleSubmit('PREVIEW')}
+            content="Preview"
+          />
+          {mode === 'DELETE' ? (
+            this.renderModal()
+          ) : (
+            <>
+              <Button
+                secondary
+                content="Import"
+                onClick={(e, props) => {
+                  this.handleImportConfirmOpen();
+                }}
+              />
+              {this.renderImportConfirm()}
+            </>
+          )}
+        </>
+      </Form>
     );
   };
 

--- a/ui/src/importer/importerTaskDetails/ImportedDocuments.js
+++ b/ui/src/importer/importerTaskDetails/ImportedDocuments.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Message, Segment, Grid, Divider } from 'semantic-ui-react';
+import { Message, Segment, Grid } from 'semantic-ui-react';
 import _isEmpty from 'lodash/isEmpty';
 import _isNull from 'lodash/isNull';
 import { RenderStatistics } from './ImporterTaskDetailsComponents/ImportStats';
@@ -9,6 +9,9 @@ import { ImporterReportHeader } from './ImporterTaskDetailsComponents/ImporterRe
 import { NotFound } from '@inveniosoftware/react-invenio-app-ils';
 import { ImporterReportStatusLabel } from './ImporterTaskDetailsComponents/ImporterReportStatusLabel';
 import { ImporterReportMode } from './ImporterTaskDetailsComponents/ImporterReportMode';
+import { ImporterProviderLabel } from './ImporterTaskDetailsComponents/ImporterProviderLabel';
+import { ImporterFilenameLabel } from './ImporterTaskDetailsComponents/ImporterFilenameLabel';
+import { ImporterDateLabel } from './ImporterTaskDetailsComponents/ImporterDateLabel';
 
 export class ImportedDocuments extends React.Component {
   constructor(props) {
@@ -27,34 +30,39 @@ export class ImportedDocuments extends React.Component {
         filterFunction: record => record,
       },
       records_created: {
-        text: 'Records created',
+        text: 'Created',
         value: 0,
         filterFunction: record => record.action === 'create',
       },
       records_deleted: {
-        text: 'Records deleted',
+        text: 'Deleted',
         value: 0,
         filterFunction: record => record.action === 'delete',
       },
       records_updated: {
-        text: 'Records updated',
+        text: 'Updated',
         value: 0,
         filterFunction: record => record.action === 'update',
       },
       records_with_errors: {
-        text: 'Records with errors',
+        text: 'with Errors',
         value: 0,
         filterFunction: record => _isNull(record.action),
       },
       records_with_item: {
-        text: 'Records with eItem',
+        text: 'with E-Item',
         value: 0,
         filterFunction: record => !_isEmpty(record.eitem),
       },
       records_with_serials: {
-        text: 'Records with Serials',
+        text: 'with Serials',
         value: 0,
         filterFunction: record => !_isEmpty(record.series),
+      },
+      records_with_partial_matches: {
+        text: 'Partial matches',
+        value: 0,
+        filterFunction: record => !_isEmpty(record.partial_matches),
       },
     };
   }
@@ -73,7 +81,6 @@ export class ImportedDocuments extends React.Component {
       const filterFunc = stats[statistic].filterFunction;
 
       const isFullRecords = statistic === 'records';
-      // the full records have no filter function
       if (isFullRecords) continue;
 
       stats[statistic].value += newRecords.filter(record =>
@@ -97,6 +104,12 @@ export class ImportedDocuments extends React.Component {
     this.setState({
       searchText: text,
       activePage: 1,
+    });
+  };
+
+  setActivePage = page => {
+    this.setState({
+      activePage: page,
     });
   };
 
@@ -175,22 +188,37 @@ export class ImportedDocuments extends React.Component {
         />
 
         {entriesReady && dataAvailable ? (
-          <Grid className="middle aligned">
-            <Grid.Column width={3}>
-              <Segment>
-                <ImporterReportMode data={data} />
-                <Divider />
-                <ImporterReportStatusLabel data={data} isLoading={isLoading} />
-              </Segment>
-            </Grid.Column>
-            <Grid.Column width={13}>
+          <>
+            <Segment>
+              <Grid columns={5} divided>
+                <Grid.Column width={2}>
+                  <ImporterReportMode data={data} />
+                </Grid.Column>
+                <Grid.Column width={3}>
+                  <ImporterReportStatusLabel
+                    data={data}
+                    isLoading={isLoading}
+                  />
+                </Grid.Column>
+                <Grid.Column width={2}>
+                  <ImporterProviderLabel data={data} />
+                </Grid.Column>
+                <Grid.Column width={2}>
+                  <ImporterDateLabel data={data} />
+                </Grid.Column>
+                <Grid.Column width={7}>
+                  <ImporterFilenameLabel data={data} />
+                </Grid.Column>
+              </Grid>
+            </Segment>
+            <Segment>
               <RenderStatistics
                 statistics={this.calculateStatistics(data, this.statistics)}
                 selectedResult={selectedResult}
                 applyFilter={this.applyFilter}
               />
-            </Grid.Column>
-          </Grid>
+            </Segment>
+          </>
         ) : (
           <span>Processing file...</span>
         )}

--- a/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImportStats.js
+++ b/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImportStats.js
@@ -8,7 +8,7 @@ export const RenderStatistics = ({
   applyFilter,
 }) => {
   return (
-    <Statistic.Group widths="seven">
+    <Statistic.Group widths="seven" size="small">
       {Object.keys(statistics).map(function(statistic, index) {
         return (
           <Statistic

--- a/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterDateLabel.js
+++ b/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterDateLabel.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { toShortDateTime } from '@inveniosoftware/react-invenio-app-ils';
+import PropTypes from 'prop-types';
+import { Label, Icon } from 'semantic-ui-react';
+import { DateTime } from 'luxon';
+
+export class ImporterDateLabel extends React.Component {
+  dateLabel = startTime => {
+    const date = toShortDateTime(DateTime.fromISO(startTime));
+    return (
+      <>
+        {' '}
+        <Icon name="calendar" /> <Label basic>{date}</Label>{' '}
+      </>
+    );
+  };
+
+  render() {
+    const { data } = this.props;
+
+    if (!data) return this.dateLabel('Missing date');
+
+    return this.dateLabel(data.start_time);
+  }
+}
+
+ImporterDateLabel.propTypes = {
+  data: PropTypes.object.isRequired,
+};

--- a/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterFilenameLabel.js
+++ b/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterFilenameLabel.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Label, Icon } from 'semantic-ui-react';
+
+export class ImporterFilenameLabel extends React.Component {
+  filenameLabel = filename => {
+    return (
+      <>
+        {' '}
+        <Icon name="file" /> <Label basic>{filename}</Label>{' '}
+      </>
+    );
+  };
+
+  render() {
+    const { data } = this.props;
+
+    if (!data) return this.filenameLabel('Missing filename');
+
+    return this.filenameLabel(data.original_filename);
+  }
+}
+
+ImporterFilenameLabel.propTypes = {
+  data: PropTypes.object.isRequired,
+};

--- a/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterProviderLabel.js
+++ b/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterProviderLabel.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Label, Icon } from 'semantic-ui-react';
+
+export class ImporterProviderLabel extends React.Component {
+  providerLabel = provider => {
+    return (
+      <>
+        {' '}
+        <Icon name="building" /> <Label basic>{provider}</Label>{' '}
+      </>
+    );
+  };
+
+  render() {
+    const { data } = this.props;
+
+    if (!data) return this.providerLabel('Missing provider');
+
+    return this.providerLabel(data.provider);
+  }
+}
+
+ImporterProviderLabel.propTypes = {
+  data: PropTypes.object.isRequired,
+};

--- a/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterReportMode.js
+++ b/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterReportMode.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Label } from 'semantic-ui-react';
+import { Label, Icon } from 'semantic-ui-react';
 
 export class ImporterReportMode extends React.Component {
   constructor(props) {
@@ -38,7 +38,12 @@ export class ImporterReportMode extends React.Component {
   render() {
     const { data } = this.props;
 
-    return <> Mode: {this.labels[data.mode]} </>;
+    return (
+      <>
+        {' '}
+        <Icon name="cog" /> {this.labels[data.mode]}{' '}
+      </>
+    );
   }
 }
 

--- a/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterReportStatusLabel.js
+++ b/ui/src/importer/importerTaskDetails/ImporterTaskDetailsComponents/ImporterReportStatusLabel.js
@@ -20,7 +20,12 @@ export class ImporterReportStatusLabel extends React.Component {
   }
 
   relevantLabel = status => {
-    return <> Status: {this.labels[status]} </>;
+    return (
+      <>
+        {' '}
+        <Icon name="upload" /> {this.labels[status]}{' '}
+      </>
+    );
   };
 
   render() {

--- a/ui/src/semantic-ui/site/views/statistic.overrides
+++ b/ui/src/semantic-ui/site/views/statistic.overrides
@@ -3,9 +3,8 @@
 *******************************/
 
 .ui.statistic.import-statistic{
-    margin-right: 15px !important;
     border-radius: 10px;
-    padding: 20px 10px;
+    padding: 1em 0em;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Allow un-tick 'Ignore missing rules'.
Remove linter warnings from the code.
Remove the , from the dates.
Display name of the uploaded file (in imports list).
Display name of the uploaded file (in import details).
Display date of the import (in imports details).
Display provider of the import (in imports list).
Add a statistic/filter to partial matches.
Fix pagination in import details.
Set the displayed names of the providers.
Ensure statistics are displayed in one row.
Rework import details page layout.
Raise an error when wrong importer is specified.
closes https://github.com/CERNDocumentServer/cds-ils/issues/611
![Screenshot from 2021-11-11 15-05-21](https://user-images.githubusercontent.com/25476209/141311760-956b7608-7dfd-4178-b53c-6f3d4f989d62.png)
![Screenshot from 2021-11-11 15-05-29](https://user-images.githubusercontent.com/25476209/141311764-5bcec625-4a00-4e67-8753-dadb8e31319f.png)
![Screenshot from 2021-11-11 15-05-35](https://user-images.githubusercontent.com/25476209/141311767-493d1243-5bcc-4578-940e-aa7a6159d6d9.png)
![Screenshot from 2021-11-11 15-05-53](https://user-images.githubusercontent.com/25476209/141311771-38734412-fa10-4ae8-b60c-da8a042ab95f.png)
![Screenshot from 2021-11-11 15-06-02](https://user-images.githubusercontent.com/25476209/141311773-9f2b90d2-8770-40c8-9720-aaccb529dd4d.png)
![Screenshot from 2021-11-11 15-06-10](https://user-images.githubusercontent.com/25476209/141311776-ae9e0e35-a858-4338-a4cb-cf9ba98a3924.png)


