### PR TITLE
Circulation: add to each loan the first item on shelf

### DIFF
--- a/cds_ils/circulation/indexer.py
+++ b/cds_ils/circulation/indexer.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+#
+# invenio-app-ils is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Loan indexer APIs."""
+
+from invenio_app_ils.proxies import current_app_ils
+
+
+def index_extra_fields_for_loan(loan_dict):
+    """Indexer hook to modify the loan record dict before indexing.
+
+    The `on_shelf_item` fields are added to the loan only on the search index
+    because they are needed for search aggregation/filtering. They are not
+    needed when fetching the loan details.
+    """
+    document_class = current_app_ils.document_record_cls
+    document_record = document_class.get_record_by_pid(
+        loan_dict.get("document_pid")
+    )
+    document = document_record.replace_refs()
+
+    on_shelf = document.get("items", []).get("on_shelf", {})
+
+    if not on_shelf:
+        loan_dict["on_shelf_item"] = {}
+        return
+
+    library = next(iter(on_shelf.values()))
+    item_suggestion = next(iter(library.values()))[0]
+
+    for field in [
+        "circulation_restriction",
+        "internal_location_pid",
+        "isbn",
+        "pid",
+        "status",
+    ]:
+        item_suggestion.pop(field, None)
+
+    loan_dict[
+        "item_suggestion"
+    ] = item_suggestion

--- a/cds_ils/circulation/serializers/__init__.py
+++ b/cds_ils/circulation/serializers/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# CDS-ILS is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Loan serializers."""
+
+from invenio_app_ils.records.schemas.json import ILSRecordSchemaJSONV1
+from invenio_app_ils.records.serializers import record_responsify_no_etag
+from invenio_records_rest.serializers.response import search_responsify
+
+from .csv import LoanCSVSerializer
+from .json import LoanJSONSerializer
+
+csv_v1 = LoanCSVSerializer(ILSRecordSchemaJSONV1)
+csv_v1_response = record_responsify_no_etag(csv_v1, "text/csv")
+csv_v1_search = search_responsify(csv_v1, "text/csv")
+
+json_v1 = LoanJSONSerializer(ILSRecordSchemaJSONV1, replace_refs=True)
+json_v1_response = record_responsify_no_etag(json_v1, "application/json")
+json_v1_search = search_responsify(json_v1, "application/json")

--- a/cds_ils/circulation/serializers/csv.py
+++ b/cds_ils/circulation/serializers/csv.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# CDS-ILS is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Literature CSV serializers."""
+
+from flask import current_app
+from invenio_app_ils.circulation.serializers.csv import \
+    LoanCSVSerializer as IlsLoanCSVSerializer
+
+from cds_ils.utils import dynamic_delete_field
+
+
+class LoanCSVSerializer(IlsLoanCSVSerializer):
+    """Serialize literature."""
+
+    def transform_record(self, pid, record, links_factory=None, **kwargs):
+        """Transform record into an intermediate representation."""
+        loan = super().transform_record(
+            pid, record, links_factory=links_factory, **kwargs
+        )
+        return loan
+
+    def transform_search_hit(
+        self, pid, record_hit, links_factory=None, **kwargs
+    ):
+        """Transform search result hit into an intermediate representation."""
+        hit = super().transform_search_hit(
+            pid, record_hit, links_factory=links_factory, **kwargs
+        )
+        return dynamic_delete_field(
+            hit, current_app.config["CDS_LOAN_SERIALIZE_FIELDS_REMOVE"]
+        )

--- a/cds_ils/circulation/serializers/json.py
+++ b/cds_ils/circulation/serializers/json.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# CDS-ILS is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Literature JSON serializers."""
+
+from flask import current_app
+from invenio_app_ils.circulation.serializers.json import \
+    LoanJSONSerializer as IlsLoanJSONSerializer
+
+from cds_ils.utils import dynamic_delete_field
+
+
+class LoanJSONSerializer(IlsLoanJSONSerializer):
+    """Serialize Literature."""
+
+    def transform_record(self, pid, record, links_factory=None, **kwargs):
+        """Transform record into an intermediate representation."""
+        loan = super().transform_record(
+            pid, record, links_factory=links_factory, **kwargs
+        )
+        return loan
+
+    def transform_search_hit(
+        self, pid, record_hit, links_factory=None, **kwargs
+    ):
+        """Transform search result hit into an intermediate representation."""
+        hit = super().transform_search_hit(
+            pid, record_hit, links_factory=links_factory, **kwargs
+        )
+        return dynamic_delete_field(
+            hit, current_app.config["CDS_LOAN_SERIALIZE_FIELDS_REMOVE"]
+        )

--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -19,6 +19,8 @@ from datetime import timedelta
 
 from celery.schedules import crontab
 from invenio_app.config import APP_DEFAULT_SECURE_HEADERS
+from invenio_app_ils.circulation.config import \
+    ILS_CIRCULATION_RECORDS_REST_ENDPOINTS
 from invenio_app_ils.circulation.transitions.transitions import \
     ILSItemOnLoanToItemOnLoan, ILSToItemOnLoan
 from invenio_app_ils.circulation.utils import circulation_can_be_requested, \
@@ -38,6 +40,7 @@ from invenio_app_ils.permissions import authenticated_user_permission, \
     backoffice_permission, loan_extend_circulation_permission, \
     patron_owner_permission
 from invenio_app_ils.series.api import SERIES_PID_TYPE
+from invenio_circulation.pidstore.pids import CIRCULATION_LOAN_PID_TYPE
 from invenio_circulation.transitions.transitions import CreatedToPending, \
     ItemOnLoanToItemReturned, ToCancelled
 from invenio_oauthclient.contrib import cern_openid
@@ -411,6 +414,17 @@ RECORDS_REST_ENDPOINTS[SERIES_PID_TYPE]["search_serializers"] = {
     "application/json": "cds_ils.series.serializers:json_v1_search",
     "text/csv": "cds_ils.series.serializers:csv_v1_search",
 }
+ILS_CIRCULATION_RECORDS_REST_ENDPOINTS[CIRCULATION_LOAN_PID_TYPE][
+    "record_serializers"
+] = {
+    "application/json": "cds_ils.circulation.serializers:json_v1_response",
+}
+ILS_CIRCULATION_RECORDS_REST_ENDPOINTS[CIRCULATION_LOAN_PID_TYPE][
+    "search_serializers"
+] = {
+    "application/json": "cds_ils.circulation.serializers:json_v1_search",
+    "text/csv": "cds_ils.circulation.serializers:csv_v1_search",
+}
 
 ###############################################################################
 # ILS overridden
@@ -637,6 +651,9 @@ CDS_ILS_SYNDETIC_CLIENT = "CHANGE_ME"
 CDS_ILS_EZPROXY_URL = "https://ezproxy.cern.ch/login?url={url}"
 # Eitem DOI URL prefix
 CDS_ILS_DOI_URL_PREFIX = 'http://dx.doi.org/{doi}'
+# Fields to remove from loan serializer.
+# Format [field1, [field2, subfield1], [field3, subfield2, subsubfield1]]
+CDS_LOAN_SERIALIZE_FIELDS_REMOVE = ["links"]
 
 ###############################################################################
 # CDS-ILS importer configuration

--- a/cds_ils/ext.py
+++ b/cds_ils/ext.py
@@ -8,9 +8,12 @@
 """CDS-ILS extension."""
 
 from flask import Blueprint
+from invenio_indexer.signals import before_record_index
 from invenio_records.signals import after_record_insert, after_record_update
 
 from cds_ils.literature.tasks import pick_identifier_with_cover
+
+from .circulation.indexer import index_extra_fields_for_loan
 
 
 class CdsIls(object):
@@ -20,6 +23,7 @@ class CdsIls(object):
         """Initialization."""
         self.register_signals(app)
         self.init_app(app)
+        self.init_loan_indexer_hook(app)
 
     def init_app(self, app):
         """Initialize app."""
@@ -39,3 +43,26 @@ class CdsIls(object):
         if app.config.get("CDS_ILS_LITERATURE_UPDATE_COVERS", True):
             after_record_insert.connect(pick_identifier_with_cover)
             after_record_update.connect(pick_identifier_with_cover)
+
+    def init_loan_indexer_hook(self, app):
+        """Custom loan indexer hook init."""
+        before_record_index.dynamic_connect(
+            before_loan_index_hook,
+            sender=app,
+            weak=False,
+            index="{0}s-{0}-v1.0.0".format("loan"),
+        )
+
+
+def before_loan_index_hook(
+    sender, json=None, record=None, index=None, **kwargs
+):
+    """Hook to transform loan record before ES indexing.
+
+    :param sender: The entity sending the signal.
+    :param json: The dumped Record dict which will be indexed.
+    :param record: The corresponding Record object.
+    :param index: The index in which the json will be indexed.
+    :param kwargs: Any other parameters.
+    """
+    index_extra_fields_for_loan(json)

--- a/cds_ils/utils.py
+++ b/cds_ils/utils.py
@@ -16,3 +16,32 @@ def format_login_required_urls(urls):
             url["login_required_url"] = current_app.config[
                 "CDS_ILS_EZPROXY_URL"
             ].format(url=url["value"])
+
+
+def dynamic_delete_field(original_element, fields):
+    """Dynamically delete an array of fields from a dictionary."""
+    # Wrong parameter in the configuration
+    wrong_field = False
+
+    for field in fields:
+        if not isinstance(field, list):
+            original_element.pop(field)
+            continue
+        if not field:
+            continue
+
+        element = original_element
+        for subfield in field[:-1]:
+            if subfield in element.keys():
+                element = element[subfield]
+            else:
+                wrong_field = True
+                break
+
+        if wrong_field:
+            wrong_field = False
+            continue
+
+        element.pop(field[-1], None)
+
+    return original_element

--- a/ui/src/importer/ImporterList.js
+++ b/ui/src/importer/ImporterList.js
@@ -5,7 +5,6 @@ import {
   toShortDateTime,
 } from '@inveniosoftware/react-invenio-app-ils';
 import _isEmpty from 'lodash/isEmpty';
-import _isNull from 'lodash/isNull';
 import { DateTime } from 'luxon';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';


### PR DESCRIPTION
This change only affects elastic search.
The first item is the first of the associated document.
Allow removing fields from the loan serializer (configurable).
closes: https://github.com/CERNDocumentServer/cds-ils/issues/499
![Screenshot from 2021-11-25 17-16-20](https://user-images.githubusercontent.com/25476209/143474821-5e2431b7-a6df-4b25-be76-0b2114dc37ce.png)
