### PR TITLE
[DEPENDS]Vocab/doc request: added message and fields

### DIFF
--- a/cds_ils/vocabularies/data/alternative_identifier_schemes.json
+++ b/cds_ils/vocabularies/data/alternative_identifier_schemes.json
@@ -2,7 +2,8 @@
   {
     "type": "alternative_identifier_scheme",
     "key": "ARXIV",
-    "text": "arXiv"
+    "text": "arXiv",
+    "data": { "url_path":  "https://arxiv.org/abs/{identifier}"}
   },
   {
     "type": "alternative_identifier_scheme",
@@ -17,7 +18,10 @@
   {
     "type": "alternative_identifier_scheme",
     "key": "INSPIRE",
-    "text": "INSPIRE"
+    "text": "INSPIRE",
+    "data": {
+      "url_path": " https://inspirehep.net/literature/{identifier}"
+    }
   },
   {
     "type": "alternative_identifier_scheme",

--- a/cds_ils/vocabularies/data/identifier_schemes.json
+++ b/cds_ils/vocabularies/data/identifier_schemes.json
@@ -2,7 +2,8 @@
   {
     "type": "identifier_scheme",
     "key": "DOI",
-    "text": "Digital Object Identifier (DOI)"
+    "text": "Digital Object Identifier (DOI)",
+    "data": {"url_path":  "https://doi.org/{identifier}"}
   },
   {
     "type": "identifier_scheme",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1479,9 +1479,9 @@
       }
     },
     "@inveniosoftware/react-invenio-app-ils": {
-      "version": "1.0.0-alpha.60",
-      "resolved": "https://registry.npmjs.org/@inveniosoftware/react-invenio-app-ils/-/react-invenio-app-ils-1.0.0-alpha.60.tgz",
-      "integrity": "sha512-c4+7RajiIfaH5wi/L2zorSRMwaxsuKKkcgfELCCcn9ZNxVH6rDaX53pZp5k7dYM237hTCFCZ78LkJi99BX6zhw=="
+      "version": "1.0.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@inveniosoftware/react-invenio-app-ils/-/react-invenio-app-ils-1.0.0-alpha.61.tgz",
+      "integrity": "sha512-QjpVZ1e6d1NKT+UBMjnLoyEF5cDBNZev0kyWUZjuydt5e8iOK7NMFPFZEJc9tsPSc3U7HdIaWz56i0UGgvEWOw=="
     },
     "@jest/console": {
       "version": "24.9.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.17",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.60",
+    "@inveniosoftware/react-invenio-app-ils": "^1.0.0-alpha.61",
     "@rjsf/core": "^2.5.0",
     "@rjsf/semantic-ui": "^2.5.0",
     "axios": "^0.21.0",

--- a/ui/src/overridableMapping.js
+++ b/ui/src/overridableMapping.js
@@ -23,6 +23,9 @@ import { SideBarMenuItem } from './overridden/backoffice/Sidebar/SideBarMenuItem
 import { ImporterRoute } from './overridden/routes/ImporterRoute';
 import { overriddenSearchAppCmps } from './overridden/frontsite/LiteratureSearch/LiteratureSearch';
 import { StandardCardView } from './overridden/frontsite/DocumentSearch/StandardCardView';
+import { LiteratureKeyword } from './overridden/frontsite/Document/DocumentDetails/DocumentCirculation/LiteratureKeyword';
+import { Identifiers } from './overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers';
+import { DocumentConference } from './overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/DocumentConference';
 
 export const overriddenCmps = {
   'Backoffice.PatronDetails.Metadata': PatronMetadata,
@@ -45,4 +48,7 @@ export const overriddenCmps = {
   LiteratureSearch: overriddenSearchAppCmps,
   'BackOfficeRoutesSwitch.CustomRoute': ImporterRoute,
   'Backoffice.Sidebar.CustomMenuItem': SideBarMenuItem,
+  'LiteratureKeywords.layout': LiteratureKeyword,
+  'DocumentMetadataTabs.Identifiers': Identifiers,
+  'DocumentConference.layout': DocumentConference,
 };

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentCirculation/LiteratureKeyword.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentCirculation/LiteratureKeyword.js
@@ -1,0 +1,11 @@
+import _isEmpty from 'lodash/isEmpty';
+
+export const LiteratureKeyword = ({ keywords }) => {
+  // hides the keyword sources
+  const keywordsIsEmpty = _isEmpty(keywords);
+
+  if (keywordsIsEmpty) return null;
+
+  const keywordValues = keywords.map(keyword => keyword?.value);
+  return keywordValues.join(';  ');
+};

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/DocumentConference.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/DocumentConference.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Divider, Table } from 'semantic-ui-react';
+import _isEmpty from 'lodash/isEmpty';
+
+export const DocumentConference = ({ conference }) => {
+  return (
+    <>
+      <Divider horizontal>Conference information</Divider>
+      {_isEmpty(conference) && 'No conference information.'}
+      {conference.map(conf => (
+        <>
+          <Table definition key={conf}>
+            <Table.Body>
+              <Table.Row>
+                <Table.Cell width={4}>Conference</Table.Cell>
+                <Table.Cell>{conf.title}</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>Acronym</Table.Cell>
+                <Table.Cell>{conf.acronym}</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>Dates</Table.Cell>
+                <Table.Cell>{conf.dates}</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>Identifiers</Table.Cell>
+                <Table.Cell>
+                  {conf.identifiers &&
+                    conf.identifiers.map(
+                      ({ scheme, value }) =>
+                        `${scheme === 'CERN' ? '' : `(${scheme})`} ${value}`
+                    )}
+                </Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>Place</Table.Cell>
+                <Table.Cell>{conf.place}</Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>Series number</Table.Cell>
+                <Table.Cell>{conf.series}</Table.Cell>
+              </Table.Row>
+            </Table.Body>
+          </Table>
+          <br />
+        </>
+      ))}
+    </>
+  );
+};
+
+DocumentConference.propTypes = {
+  conference: PropTypes.object,
+};
+
+DocumentConference.defaultProps = {
+  conference: [],
+};

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/Identifiers.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/Identifiers.js
@@ -1,0 +1,153 @@
+import {
+  InfoPopup,
+  SeparatedList,
+} from '@inveniosoftware/react-invenio-app-ils';
+import capitalize from 'lodash/capitalize';
+import _isEmpty from 'lodash/isEmpty';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Divider, Table, Loader } from 'semantic-ui-react';
+
+// component not to be used in search pages
+// might trigger a lot of requests
+export class Identifiers extends Component {
+  componentDidMount() {
+    const { fetchVocabularyIdentifiers } = this.props;
+    fetchVocabularyIdentifiers();
+  }
+
+  render() {
+    const { identifiers, loading, vocabularyIdentifiers } = this.props;
+
+    const noIdentifiers = _isEmpty(identifiers);
+
+    if (noIdentifiers) {
+      return (
+        <>
+          <Divider horizontal>Identifiers</Divider>
+          'No identifiers'
+        </>
+      );
+    }
+
+    return (
+      <>
+        <Divider horizontal>Identifiers</Divider>
+        {loading ? (
+          <Loader />
+        ) : (
+          <Table definition>
+            <Table.Body>
+              <IdentifierRows
+                identifiers={identifiers}
+                vocabularyIdentifiers={vocabularyIdentifiers}
+              />
+            </Table.Body>
+          </Table>
+        )}
+      </>
+    );
+  }
+}
+
+Identifiers.propTypes = {
+  identifiers: PropTypes.array,
+  vocabularyIdentifiers: PropTypes.array,
+  fetchVocabularyIdentifiers: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
+};
+
+Identifiers.defaultProps = {
+  identifiers: [],
+  vocabularyIdentifiers: null,
+};
+
+export const IdentifierRows = ({
+  includeSchemes,
+  identifiers,
+  vocabularyIdentifiers,
+}) => {
+  const idsByScheme = {};
+
+  for (const id of identifiers) {
+    // Only include whitelisted schemes if includeSchemes is set
+    if (includeSchemes.length === 0 || includeSchemes.includes(id.scheme)) {
+      const value = createValueObject(
+        vocabularyIdentifiers,
+        id.value,
+        id.scheme,
+        id.material
+      );
+
+      if (id.scheme in idsByScheme) {
+        idsByScheme[id.scheme].push(value);
+      } else {
+        idsByScheme[id.scheme] = [value];
+      }
+    }
+  }
+
+  return Object.entries(idsByScheme).map(([scheme, ids]) => {
+    const values = ids.map(id => (
+      <>
+        {id.urlPath ? (
+          <a href={id.urlPath} target="_blank" rel="noreferrer noopener">
+            {id.value}
+          </a>
+        ) : (
+          id.value
+        )}
+
+        {id.material && (
+          <>
+            {' '}
+            <InfoPopup message="Material for this identifier">
+              ({capitalize(id.material)})
+            </InfoPopup>
+          </>
+        )}
+      </>
+    ));
+
+    return (
+      <Table.Row key={scheme}>
+        <Table.Cell width={4}>{scheme}</Table.Cell>
+        <Table.Cell>
+          <SeparatedList items={values} />
+        </Table.Cell>
+      </Table.Row>
+    );
+  });
+};
+
+const createValueObject = (vocabularyIdentifiers, value, scheme, material) => {
+  const noVocabulariesIdentifiers = !vocabularyIdentifiers?.length;
+  const defaultValue = { value, material };
+
+  if (noVocabulariesIdentifiers) return defaultValue;
+
+  const matchingVocabularyIdentifier = vocabularyIdentifiers.find(
+    identifier => identifier.value === scheme
+  );
+
+  const notValidForUrl =
+    !matchingVocabularyIdentifier || !matchingVocabularyIdentifier.url_path;
+
+  if (notValidForUrl) return defaultValue;
+
+  const urlPath = matchingVocabularyIdentifier.url_path.replace(
+    '{identifier}',
+    value
+  );
+
+  return { value, material, urlPath };
+};
+
+IdentifierRows.propTypes = {
+  includeSchemes: PropTypes.array,
+  identifiers: PropTypes.array,
+};
+
+IdentifierRows.defaultProps = {
+  includeSchemes: [],
+};

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/actions.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/actions.js
@@ -1,0 +1,72 @@
+import { vocabularyApi } from '@inveniosoftware/react-invenio-app-ils';
+
+export const IS_LOADING = 'fetchIdentifiers/IS_LOADING';
+export const SUCCESS = 'fetchIdentifiers/SUCCESS';
+export const HAS_ERROR = 'fetchIdentifiers/HAS_ERROR';
+
+const createQueryPromise = type => {
+  const query = vocabularyApi
+    .query()
+    .withType(type)
+    .qs();
+
+  return vocabularyApi.list(query);
+};
+
+const serializer = hit => ({
+  value: hit.metadata.key,
+  text: hit.metadata.text,
+  url_path: hit.metadata?.data?.url_path,
+});
+
+const query = async () => {
+  const {
+    data: { hits: identifierQuery },
+  } = await createQueryPromise('identifier_scheme');
+  const {
+    data: { hits: alternativeIdentifierQuery },
+  } = await createQueryPromise('alternative_identifier_scheme');
+
+  const combinedHits = identifierQuery.concat(alternativeIdentifierQuery);
+
+  return combinedHits.map(serializer);
+};
+
+const identifierCache = () => {
+  let value = null;
+
+  return {
+    set: valueToSet => (value = valueToSet),
+    get: () => value,
+  };
+};
+
+const cache = identifierCache();
+
+export const fetchVocabularyIdentifiers = () => {
+  return async dispatch => {
+    dispatch({ type: IS_LOADING });
+
+    const fetchedVocabularyIdentifiers = cache.get();
+
+    try {
+      if (fetchedVocabularyIdentifiers) {
+        dispatch({
+          type: SUCCESS,
+          payload: fetchedVocabularyIdentifiers,
+        });
+      } else {
+        const queries = await query();
+
+        cache.set(queries);
+
+        dispatch({
+          type: SUCCESS,
+          payload: queries,
+        });
+      }
+    } catch (error) {
+      dispatch({ type: HAS_ERROR, payload: error });
+    }
+  };
+};

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/index.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/index.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import { fetchVocabularyIdentifiers } from './actions';
+import { Identifiers as IdentifiersComponent } from './Identifiers';
+
+const mapDispatchToProps = dispatch => ({
+  fetchVocabularyIdentifiers: () => dispatch(fetchVocabularyIdentifiers()),
+});
+
+const mapStateToProps = state => ({
+  vocabularyIdentifiers: state.vocabularyIdentifiers.data,
+  loading: state.vocabularyIdentifiers.isLoading,
+  error: state.vocabularyIdentifiers.error,
+});
+
+export const Identifiers = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(IdentifiersComponent);

--- a/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/reducer.js
+++ b/ui/src/overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/reducer.js
@@ -1,0 +1,21 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './actions';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: null,
+  error: {},
+};
+
+export const vocabularyIdentifiersReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return { ...state, data: action.payload, isLoading: false };
+    case HAS_ERROR:
+      return { ...state, hasError: action.payload, isLoading: false };
+    default:
+      return state;
+  }
+};

--- a/ui/src/overridden/frontsite/DocumentRequest/DocumentRequestFormHeader.js
+++ b/ui/src/overridden/frontsite/DocumentRequest/DocumentRequestFormHeader.js
@@ -12,6 +12,10 @@ export const DocumentRequestFormHeader = () => {
         document (book, article, standard, etc.) to the Library.
       </p>
       <p>
+        We will do our best to give you access to e-books, but please note that
+        not all books are made available as e-books by providers.
+      </p>
+      <p>
         You can see all your requests on your{' '}
         <Link to={FrontSiteRoutes.patronProfile}>profile</Link> page.
       </p>

--- a/ui/src/reducers.js
+++ b/ui/src/reducers.js
@@ -10,6 +10,9 @@ const seriesDetailsModalViewReducer = require('./importer/SeriesImportDetailsMod
 const eitemDetailsModalViewReducer = require('./importer/EitemImportDetailsModal/reducer')
   .eitemDetailsModalViewReducer;
 
+const vocabularyIdentifiersReducer = require('./overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers/reducer')
+  .vocabularyIdentifiersReducer;
+
 export function initialiseReducers() {
   injectAsyncReducer(ILSStore, 'jsonModal', jsonModalViewReducer);
   injectAsyncReducer(
@@ -21,5 +24,10 @@ export function initialiseReducers() {
     ILSStore,
     'seriesDetailsModal',
     seriesDetailsModalViewReducer
+  );
+  injectAsyncReducer(
+    ILSStore,
+    'vocabularyIdentifiers',
+    vocabularyIdentifiersReducer
   );
 }


### PR DESCRIPTION
Added a extra clarification message on the document request from in the front-site and also added some vocabulary fields to identifiers to make them clickable.


DESKTOP -> 

![image](https://user-images.githubusercontent.com/55200060/145589119-5bfda175-69cc-49a9-94b7-0fdef20b796b.png)

![image](https://user-images.githubusercontent.com/55200060/145592294-64523529-7304-4a97-b034-cc005a6186c3.png)


MOBILE -> 

<img width="388" alt="Capture d’écran 2022-01-11 à 17 16 14" src="https://user-images.githubusercontent.com/55200060/148980100-a200b1af-053f-45f8-99b4-2f492c9e4455.png">

<img width="355" alt="Capture d’écran 2022-01-11 à 16 32 58" src="https://user-images.githubusercontent.com/55200060/148980121-2cbc3532-719d-4ce7-9eb2-d27671d9c7d9.png">


closes https://github.com/CERNDocumentServer/cds-ils/issues/526
depends on https://github.com/inveniosoftware/react-invenio-app-ils/pull/515