### PR TITLE
importer: validate provider identifiers

### DIFF
--- a/tests/importer/data/existing_documents.json
+++ b/tests/importer/data/existing_documents.json
@@ -74,6 +74,28 @@
   {
     "$schema": "https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json",
     "created_by": { "type": "script", "value": "test" },
+    "pid": "docid-41",
+    "title": "Locking Up Our Own: Crime and Punishment in Black America",
+    "authors": [{ "full_name": "James Forman Jr." }],
+    "abstract": "This is an abstract",
+    "keywords": [
+      {
+        "source": "X",
+        "value": "Patata"
+      }
+    ],
+    "document_type": "BOOK",
+    "publication_year": "1950",
+    "alternative_identifiers": [
+      {
+        "scheme": "SPR",
+        "value": "SPR123"
+      }],
+    "note": "MATCH BY TITLE but different provider IDs"
+  },
+  {
+    "$schema": "https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json",
+    "created_by": { "type": "script", "value": "test" },
     "pid": "docid-5",
     "title": "Camera, equipment, and basic photographic techniques",
     "authors": [

--- a/tests/importer/data/match_testing_documents.json
+++ b/tests/importer/data/match_testing_documents.json
@@ -48,5 +48,25 @@
     "document_type": "THESIS",
     "publication_year": "1950",
     "note": "FUZZY MATCH"
+  },
+    {
+    "$schema": "https://127.0.0.1:5000/schemas/documents/document-v1.0.0.json",
+    "created_by": {"type": "script", "value":  "test"},
+    "title": "Locking Up Our Own: Crime and Punishment in Black America",
+    "authors": [{ "full_name": "James Forman Jr." }],
+    "abstract": "This is an abstract",
+    "keywords": [
+      {
+        "source": "X",
+        "value": "Patata"
+      }],
+    "document_type": "BOOK",
+    "publication_year": "1950",
+    "alternative_identifiers": [
+      {
+        "scheme": "SPR",
+        "value": "SPR321"
+      }],
+    "note": "MATCH BY TITLE but different provider IDs"
   }
 ]

--- a/tests/importer/test_document_matching.py
+++ b/tests/importer/test_document_matching.py
@@ -7,7 +7,7 @@ from ..helpers import load_json_from_datadir
 def test_document_search_matching(importer_test_data):
     helper_metadata_fields = ("_items", "agency_code")
     metadata_provider = "springer"
-    update_document_fields = ("identifiers",)
+    update_document_fields = ("identifiers", "alternative_identifiers")
 
     data_to_update = load_json_from_datadir(
         "match_testing_documents.json", relpath="importer"
@@ -50,8 +50,25 @@ def test_document_search_matching(importer_test_data):
     )
 
     matches = document_importer.search_for_matching_documents()
+    validated_matches, partial = document_importer. \
+        validate_found_matches(matches)
 
-    assert matches == ["docid-4"]
+    assert validated_matches == "docid-4"
+
+    # test matching by title and authors but different ids
+    document_importer = DocumentImporter(
+        data_to_update[4],
+        helper_metadata_fields,
+        metadata_provider,
+        update_document_fields,
+    )
+
+    matches = document_importer.search_for_matching_documents()
+    validated_matches, partial = document_importer. \
+        validate_found_matches(matches)
+
+    assert validated_matches == "docid-4"
+    assert partial == ["docid-41"]
 
 
 def test_fuzzy_matching(importer_test_data):


### PR DESCRIPTION
* remove incorrect matching based on provider ids
* closes https://cern.service-now.com/nav_to.do?uri=u_request_fulfillment.do?sys_id=d682586a1b8d8110e823a71eab4bcb4a