### PR TITLE
importer details: non existing task page

### DIFF
--- a/cds_ils/importer/views.py
+++ b/cds_ils/importer/views.py
@@ -84,24 +84,28 @@ class ImporterDetailsView(ContentNegotiatedMethodView):
         """Returns the detail views of each subtask by given offset."""
         try:
             log = db.session.query(ImporterImportLog).get(log_id)
+
+            if log is None:
+                abort(404, "Task does not exist.")
+
             return self.make_response(log, record_offset=offset)
         except ObjectDeletedError:
             abort(404, "The task log was deleted.")
-        except NoResultFound:
-            abort(404, "Task does not exist.")
 
     @need_permissions("document-importer")
     def post(self, log_id):
         """Cancels the ongoing celery task."""
         try:
             log = db.session.query(ImporterImportLog).get(log_id)
+
+            if log is None:
+                abort(404, "Task does not exist.")
+
             log.set_cancelled()
             db.session.commit()
             return self.make_response(log, code=200)
         except ObjectDeletedError:
             abort(404, "The task log was deleted.")
-        except NoResultFound:
-            abort(404, "Task does not exist.")
 
 
 class ImporterListView(ContentNegotiatedMethodView):

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ history = open("CHANGES.rst").read()
 tests_require = [
     "Sphinx>=3.1.1,<5",
     "mock>=2.0.0",
-    "pytest-invenio>=1.4.0",
+    "pytest-invenio>=1.4.13",
     "pytest-mock>=1.6.0",
     "pytest-random-order>=0.5.4",
 ]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ history = open("CHANGES.rst").read()
 tests_require = [
     "Sphinx>=3.1.1,<5",
     "mock>=2.0.0",
-    "pytest-invenio>=1.4.13",
+    "pytest-invenio>=1.4.0",
     "pytest-mock>=1.6.0",
     "pytest-random-order>=0.5.4",
 ]


### PR DESCRIPTION
* throw 404 error manually for non existing task
* closes https://github.com/CERNDocumentServer/cds-ils/issues/759

"Pretty" 404 error page displaying preview:

![Importer-404-error-page](https://user-images.githubusercontent.com/61321254/183427952-ff61e8bb-3065-4ebc-9520-7e29e0d3073e.gif)

