### PR TITLE
ui: frontsite: Update Overridable opening hours header and details component

### DIFF
--- a/ui/src/overridableMapping.js
+++ b/ui/src/overridableMapping.js
@@ -24,6 +24,7 @@ import { LiteratureKeyword } from "./overridden/frontsite/Document/DocumentDetai
 import { Identifiers } from "./overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/Identifiers";
 import { DocumentConference } from "./overridden/frontsite/Document/DocumentDetails/DocumentMetadataTabs/DocumentConference";
 import { DocumentItemsHeader } from "./overridden/frontsite/Document/DocumentDetails/DocumentItemsHeader";
+import { OpeningHoursDetails } from "./overridden/frontsite/OpeningHours/OpeningHoursDetails";
 
 export const overriddenCmps = {
   "Backoffice.PatronDetails.Metadata": PatronMetadata,
@@ -50,4 +51,5 @@ export const overriddenCmps = {
   "DocumentMetadataTabs.Identifiers": Identifiers,
   "DocumentConference.layout": DocumentConference,
   "DocumentDetails.DocumentItems.header": DocumentItemsHeader,
+  "OpeningHours.details": OpeningHoursDetails,
 };

--- a/ui/src/overridden/frontsite/OpeningHours/OpeningHoursDetails.js
+++ b/ui/src/overridden/frontsite/OpeningHours/OpeningHoursDetails.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { Header, Message } from "semantic-ui-react";
+
+export const OpeningHoursDetails = () => {
+  return (
+    <>
+      <Header as="h2">Opening hours</Header>
+      <Message info>
+        <Message.Content>
+          The CERN community can access the library, located in <b>52/1-052, </b>
+          <b>
+            <u>24/7</u>
+          </b>
+          !
+          <br />
+          Staff is available to help at the Library and Bookshop Welcome Desk, located
+          in
+          <b> 52/1-054</b>, open as per the schedule below :
+          <br />
+        </Message.Content>
+      </Message>
+    </>
+  );
+};


### PR DESCRIPTION
Closes: https://github.com/CERNDocumentServer/cds-ils/issues/353

![Screenshot 2024-01-09 at 15 32 33](https://github.com/CERNDocumentServer/cds-ils/assets/50872172/da83f863-3ffb-49b7-85a2-7a2616d34410)
