### PR TITLE
fix(tests): add missing rabbit mq service

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -40,7 +40,7 @@ if [[ ${keep_services} -eq 0 ]]; then
 fi
 
 python -m check_manifest
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch2} --cache ${CACHE:-redis} --env)"
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch2} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
 python -m pytest ${pytest_args[@]+"${pytest_args[@]}"}
 tests_exit_code=$?
 exit "$tests_exit_code"


### PR DESCRIPTION
Records are created by fixtures before running tests.
GIven that now you have added on insert, edit and delete signal for stats, you need to have Rabbit MQ up and running when testing.