### PR TITLE
Increased importer max file size

### DIFF
--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -803,4 +803,4 @@ ILS_SELF_CHECKOUT_ENABLED = True
 # REST_CSRF_ENABLED = False
 
 # Enable larger file uploads for importer - 1GiB
-MAX_CONTENT_LENGTH = 1000 * 1024 * 1024  
+MAX_CONTENT_LENGTH = 1000 * 1024 * 1024

--- a/cds_ils/config.py
+++ b/cds_ils/config.py
@@ -798,3 +798,9 @@ SECURITY_PASSWORD_SINGLE_HASH = True
 
 # Feature Toggles
 ILS_SELF_CHECKOUT_ENABLED = True
+
+# Enable for local dev to stop CSRF token error
+# REST_CSRF_ENABLED = False
+
+# Enable larger file uploads for importer - 1GiB
+MAX_CONTENT_LENGTH = 1000 * 1024 * 1024  


### PR DESCRIPTION
Changed overlay configuration to allow for the importer to import files up to 1GiB.

* closes https://github.com/CERNDocumentServer/cds-ils/issues/877