### PR TITLE
feat(rdm): sync publication-thesis as THESIS with no tags

### DIFF
--- a/cds_ils/importer/json/rdm/transform.py
+++ b/cds_ils/importer/json/rdm/transform.py
@@ -36,9 +36,9 @@ alt_titles_types_map = {
     "alternative-title": "ALTERNATIVE_TITLE",
 }
 
-document_type_map = {"publication-thesis": "BOOK"}
+document_type_map = {"publication-thesis": "THESIS"}
 
-document_type_tags_map = {"publication-thesis": "THESIS"}
+document_type_tags_map = {}
 
 conference_identifiers_scheme_map = {"url": "OTHER", "inspire": "INSPIRE_CNUM"}
 

--- a/tests/importer/json/test_json_import.py
+++ b/tests/importer/json/test_json_import.py
@@ -39,7 +39,7 @@ def test_rdm_import(app):
         {"value": "CMS-TS-2015-021", "scheme": "REPORT_NUMBER"},
         {"value": "CMS-TS-2015-021", "scheme": "REPORT_NUMBER"},
     ]
-    assert matched_document["document_type"] == "BOOK"
+    assert matched_document["document_type"] == "THESIS"
 
     series1pid = report["series"][0]["series_record"]["pid"]
     series2pid = report["series"][1]["series_record"]["pid"]

--- a/tests/importer/json/test_rdm_import.py
+++ b/tests/importer/json/test_rdm_import.py
@@ -66,7 +66,7 @@ def test_rdm_transformation(app):
             }
         ],
         "copyrights": [{"statement": "2025 © Author(s)"}],
-        "document_type": "BOOK",
+        "document_type": "THESIS",
         "edition": "2",
         "extensions": {
             "unit_accelerator": "CERN LHC",
@@ -101,7 +101,6 @@ def test_rdm_transformation(app):
         "source": "CDS",
         # "subjects": None, # todo when UDC introduced in CDS_RDM
         "table_of_content": ["1. Chapter 1: ABC\n 2. Chapter 2: EFG"],
-        "tags": ["THESIS"],
         "title": "Discovery and Characterization of a Higgs boson using four-lepton events from the CMS experiment",
         "urls": [{"value": "https://url.example.com/test"}],
         "restricted": False,


### PR DESCRIPTION
Related to RQF3869780

* I am keeping the empty document_type_tags_map dictionary for consistency in case anything needs to be added in the future.

* All records are synced as BOOK unless otherwise specified in document_type_map, so the thesis needs to be explicitly specified.